### PR TITLE
useAppVersionURL parameter to use upload new version URL

### DIFF
--- a/src/main/java/hockeyapp/HockeyappRecorder.java
+++ b/src/main/java/hockeyapp/HockeyappRecorder.java
@@ -99,11 +99,17 @@ public class HockeyappRecorder extends Recorder {
 		return this.numberOldVersions;
 	}
 
-	@DataBoundConstructor
+    private Boolean useAppVersionURL;
+
+    public Boolean getUseAppVersionURL() {
+        return useAppVersionURL;
+    }
+
+    @DataBoundConstructor
 	public HockeyappRecorder(String apiToken, String appId, Boolean notifyTeam,
 			String buildNotes, String filePath, String dsymPath, String tags,
 			Boolean downloadAllowed, Boolean useChangelog, Boolean cleanupOld,
-			String numberOldVersions) {
+			String numberOldVersions,Boolean useAppVersionURL) {
 		this.apiToken = apiToken;
 		this.appId = appId;
 		this.notifyTeam = notifyTeam;
@@ -115,6 +121,7 @@ public class HockeyappRecorder extends Recorder {
 		this.useChangelog = useChangelog;
 		this.cleanupOld = cleanupOld;
 		this.numberOldVersions = numberOldVersions;
+        this.useAppVersionURL = useAppVersionURL;
 	}
 
 	@Override
@@ -147,8 +154,19 @@ public class HockeyappRecorder extends Recorder {
 			listener.getLogger().println(file);
 
 			HttpClient httpclient = new DefaultHttpClient();
-			HttpPost httpPost = new HttpPost(
-					"https://rink.hockeyapp.net/api/2/apps/upload");
+            HttpPost httpPost;
+            if(useAppVersionURL) {
+                if( StringUtils.isBlank(appId)) {
+                    listener.getLogger().println("appID is blank, can not build AppVersion upload URL. Set appID or disable useAppVersionURL.");
+                    return false;
+                }
+                httpPost = new HttpPost(
+                        "https://rink.hockeyapp.net/api/2/apps/" + appId +"/app_versions");
+            } else {
+                httpPost = new HttpPost(
+                        "https://rink.hockeyapp.net/api/2/apps/upload");
+
+            }
 			FileBody fileBody = new FileBody(file);
 			httpPost.setHeader("X-HockeyAppToken", apiToken);
 			MultipartEntity entity = new MultipartEntity();

--- a/src/main/resources/hockeyapp/HockeyappRecorder/config.jelly
+++ b/src/main/resources/hockeyapp/HockeyappRecorder/config.jelly
@@ -44,5 +44,8 @@
     <f:entry title="Numbers of old versions to keep" field="numberOldVersions">
         <f:textbox />
     </f:entry>
+    <f:entry title="Use upload new version URL" field="useAppVersionURL">
+        <f:checkbox />
+    </f:entry>
   </f:advanced>
 </j:jelly>

--- a/src/main/resources/hockeyapp/HockeyappRecorder/help-useAppVersionURL.html
+++ b/src/main/resources/hockeyapp/HockeyappRecorder/help-useAppVersionURL.html
@@ -1,0 +1,3 @@
+<div>
+Use upload new version URL "https://rink.hockeyapp.net/api/2/apps/IDENTIFIER/app_versions". If true, AppID must be provided.
+</div>


### PR DESCRIPTION
Upload version URL for Hockeyapp is defined here:
http://support.hockeyapp.net/kb/api/api-upload-new-versions

The provided boolean parameter will switch betwenn the standard add app URL:
"https://rink.hockeyapp.net/api/2/apps"
and upload version URL:
"https://rink.hockeyapp.net/api/2/apps/IDENTIFIER/app_versions"
