### PR TITLE
change the labels and documentation around 'ipa' and 'dsym' plugin fields

### DIFF
--- a/src/main/resources/hockeyapp/HockeyappRecorder/config.jelly
+++ b/src/main/resources/hockeyapp/HockeyappRecorder/config.jelly
@@ -16,10 +16,10 @@
     <f:textbox />
   </f:entry>
 
-  <f:entry title="IPA File" field="filePath">
+  <f:entry title="App File (.ipa, .app.zip, .apk)" field="filePath">
     <f:textbox />
   </f:entry>
-  <f:entry title="dSYM File" field="dsymPath">
+  <f:entry title="dSYM File (.dSYM.zip or mapping.txt)" field="dsymPath">
     <f:textbox />
   </f:entry>
   <f:entry title="Build Notes" field="buildNotes">

--- a/src/main/resources/hockeyapp/HockeyappRecorder/help-dsymPath.html
+++ b/src/main/resources/hockeyapp/HockeyappRecorder/help-dsymPath.html
@@ -1,5 +1,5 @@
 <div>
-The path to the generated dsym.zip file.
+The path to the generated dSYM.zip (iOS and MacOS) or mapping.txt (Android) file.
 eg. "MyApp/build/Beta-iphoneos/MyApp-Beta-${BUILD_NUMBER}.dsym.zip if your use ${BUILD_NUMBER} as technical version number (CFBundleShortVersionString).
 <a href="https://github.com/ohoeltke/hockeyapp-plugin/issues/1">Currently hockeyapp does not like the zip files generated from xcode-plugin.</a>
 </div>

--- a/src/main/resources/hockeyapp/HockeyappRecorder/help-filePath.html
+++ b/src/main/resources/hockeyapp/HockeyappRecorder/help-filePath.html
@@ -1,4 +1,4 @@
 <div>
-The path to the generated ipa file.
+The path to the generated ipa (iOS), .app.zip (MacOS), or .apk (Android) file.
 eg. "MyApp/build/Beta-iphoneos/MyApp-Beta-${BUILD_NUMBER}.ipa if your use ${BUILD_NUMBER} as technical version number (CFBundleShortVersionString).
 </div>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -2,5 +2,6 @@
   This view is used to render the installed plugins page.
 -->
 <div>
-  This plugin will upload a .ipa and .dsym file to hockeyapp.net for distribution.
+  This plugin allows you to upload new versions of your iOS (.ipa),
+  MacOS (.app), and Android (.apk) applictions to hockeyapp.net.
 </div>


### PR DESCRIPTION
due to changes to the _documentation_ on the HockeyApp site, i propose
that the plugin describe all the file types that can be uploaded in the
'ipa' and 'dsym' fields of the HockeyApp 'Upload New Versions' API.

http://support.hockeyapp.net/kb/api/api-upload-new-versions
- ipa - optional (required, if dsym is not specified for iOS or Mac),
    file data of the .ipa for iOS, .app.zip for Mac OS X, or .apk
    file for Android
- dsym - optional, file data of the .dSYM.zip file (iOS and Mac) or
     mapping.txt (Android)

see also this discussion:

http://support.hockeyapp.net/discussions/questions/1538-jenkins-ci-is-there-an-upload-apiplugin-for-macos-apps
