### PR TITLE
[JENKINS-19636] Allow wildcards for App file path (.ipa, .apk) and Sym path

### DIFF
--- a/src/main/java/hockeyapp/HockeyappRecorder.java
+++ b/src/main/java/hockeyapp/HockeyappRecorder.java
@@ -22,6 +22,7 @@ import org.apache.http.entity.mime.content.StringBody;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.client.HttpClient;
+import org.apache.tools.ant.types.FileSet;
 import org.json.simple.parser.JSONParser;
 import org.kohsuke.stapler.DataBoundConstructor;
 import hudson.scm.ChangeLogSet.Entry;
@@ -103,8 +104,10 @@ public class HockeyappRecorder extends Recorder {
 			tempDir.delete();
 			tempDir.mkdirs();
 
-			File file = getFileLocally(build.getWorkspace(),
-					vars.expand(filePath), tempDir);
+			FileSet fileSet = Util.createFileSet(new File(build.getWorkspace().getRemote()),
+					vars.expand(filePath), null);
+			// Take the first one that matches the pattern
+			File file = new File(fileSet.iterator().next().toString());
 			listener.getLogger().println(file);
 
 			HttpClient httpclient = new DefaultHttpClient();
@@ -153,8 +156,10 @@ public class HockeyappRecorder extends Recorder {
 			entity.addPart("ipa", fileBody);
 
 			if (dsymPath != null) {
-				File dsymFile = getFileLocally(build.getWorkspace(),
-						vars.expand(dsymPath), tempDir);
+				FileSet dsymFileSet = Util.createFileSet(new File(build.getWorkspace().getRemote()),
+					vars.expand(dsymPath), null);
+				// Take the first one that matches the pattern
+				File dsymFile = new File(dsymFileSet.iterator().next().toString());
 				listener.getLogger().println(dsymFile);
 				FileBody dsymFileBody = new FileBody(dsymFile);
 				entity.addPart("dsym", dsymFileBody);

--- a/src/main/resources/hockeyapp/HockeyappRecorder/help-dsymPath.html
+++ b/src/main/resources/hockeyapp/HockeyappRecorder/help-dsymPath.html
@@ -3,4 +3,7 @@ An optional path, relative to the build's workspace, to the generated dSYM.zip (
 You can include build variables here like <code>${BUILD_NUMBER}</code> and they'll be expanded at build time.<br/>
 <p/>
 e.g. "MyApp/build/Beta-iphoneos/MyApp-Beta-${BUILD_NUMBER}.dsym.zip if your use ${BUILD_NUMBER} as technical version number (CFBundleShortVersionString).
+<p/>
+Can use wildcards like 'module/dist/**/*.dSYM.zip'.
+See <a href='http://ant.apache.org/manual/Types/fileset.html'> the @includes of Ant fileset</a> for the exact format.
 </div>

--- a/src/main/resources/hockeyapp/HockeyappRecorder/help-filePath.html
+++ b/src/main/resources/hockeyapp/HockeyappRecorder/help-filePath.html
@@ -3,4 +3,7 @@ The path, relative to the build's workspace, to the generated .ipa (iOS), .app.z
 You can include build variables here like <code>${BUILD_NUMBER}</code> and they'll be expanded at build time.
 <p/>
 e.g. "MyApp/build/Beta-iphoneos/MyApp-Beta-${BUILD_NUMBER}.ipa if your use ${BUILD_NUMBER} as technical version number (CFBundleShortVersionString).
+<p/>
+Can use wildcards like 'module/dist/**/*.ipa'.
+See <a href='http://ant.apache.org/manual/Types/fileset.html'> the @includes of Ant fileset</a> for the exact format.
 </div>


### PR DESCRIPTION
I needed https://issues.jenkins-ci.org/browse/JENKINS-19636 resolved locally, so I made a quick-fix to do it. I've tested this and it works for me.

One part I don't understand is the intricacies of getFileLocally(). If I need that in some way, feel free to let me know how and I can try to incorporate it.
