### PR TITLE
add possibility to set private field when uploading new app

### DIFF
--- a/src/main/java/hockeyapp/HockeyappRecorder.java
+++ b/src/main/java/hockeyapp/HockeyappRecorder.java
@@ -14,6 +14,7 @@ import hudson.util.RunList;
 import net.hockeyapp.jenkins.releaseNotes.FileReleaseNotes;
 import net.hockeyapp.jenkins.releaseNotes.ManualReleaseNotes;
 import net.hockeyapp.jenkins.releaseNotes.NoReleaseNotes;
+import net.hockeyapp.jenkins.uploadMethod.AppCreation;
 import net.hockeyapp.jenkins.uploadMethod.VersionCreation;
 import net.sf.json.JSONObject;
 import org.apache.commons.collections.CollectionUtils;
@@ -243,6 +244,11 @@ public class HockeyappRecorder extends Recorder {
                 entity.addPart("notify", new StringBody(application.notifyTeam ? "1" : "0"));
                 entity.addPart("status",
                         new StringBody(application.downloadAllowed ? "2" : "1"));
+
+                if (application.uploadMethod instanceof AppCreation) {
+                    AppCreation appCreation = (AppCreation) application.uploadMethod;
+                    entity.addPart("private", new StringBody(appCreation.publicPage ? "false" : "true"));
+                }
                 httpPost.setEntity(entity);
 
                 long startTime = System.currentTimeMillis();

--- a/src/main/java/hockeyapp/HockeyappRecorderConverter.java
+++ b/src/main/java/hockeyapp/HockeyappRecorderConverter.java
@@ -104,7 +104,7 @@ public class HockeyappRecorderConverter implements Converter {
                 if (useAppVersionURL && (appId != null)) {
                     uploadMethod = new VersionCreation(appId);
                 } else {
-                    uploadMethod = new AppCreation();
+                    uploadMethod = new AppCreation(false);
                 }
             }
 

--- a/src/main/java/net/hockeyapp/jenkins/uploadMethod/AppCreation.java
+++ b/src/main/java/net/hockeyapp/jenkins/uploadMethod/AppCreation.java
@@ -8,13 +8,17 @@ import net.hockeyapp.jenkins.RadioButtonSupportDescriptor;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.export.Exported;
 
 
 public class AppCreation extends RadioButtonSupport {
+    @Exported
+    public boolean publicPage;
 
     @DataBoundConstructor
-    public AppCreation() {
+    public AppCreation(boolean publicPage) {
 
+        this.publicPage = publicPage;
     }
 
     public Descriptor<RadioButtonSupport> getDescriptor() {
@@ -36,7 +40,8 @@ public class AppCreation extends RadioButtonSupport {
 
         @Override
         public RadioButtonSupport newInstance(StaplerRequest req, JSONObject formData) throws FormException {
-            return new AppCreation();
+            boolean isPublicPage = formData.getBoolean("publicPage");
+            return new AppCreation(isPublicPage);
         }
     }
 }

--- a/src/main/resources/net/hockeyapp/jenkins/uploadMethod/AppCreation/config.jelly
+++ b/src/main/resources/net/hockeyapp/jenkins/uploadMethod/AppCreation/config.jelly
@@ -1,0 +1,6 @@
+<j:jelly xmlns:j="jelly:core"
+         xmlns:f="/lib/form">
+    <f:entry title="${%Public Page}" field="publicPage">
+        <f:checkbox />
+    </f:entry>
+</j:jelly>


### PR DESCRIPTION
This pull requests adds the possibility to set the private field when the upload method is to create a new app. It defaults to true, since this is what the HockeyApp api seems to do, although the documentation states the default is false.