### PR TITLE
Allow non-default OldVersionHolder in a Jenkins pipeline

### DIFF
--- a/src/main/java/hockeyapp/HockeyappApplication.java
+++ b/src/main/java/hockeyapp/HockeyappApplication.java
@@ -7,6 +7,7 @@ import hudson.model.Describable;
 import hudson.model.Descriptor;
 import hudson.util.FormValidation;
 import jenkins.model.Jenkins;
+import net.hockeyapp.jenkins.OldVersionHolder;
 import net.hockeyapp.jenkins.RadioButtonSupport;
 import net.hockeyapp.jenkins.RadioButtonSupportDescriptor;
 import net.hockeyapp.jenkins.releaseNotes.ChangelogReleaseNotes;
@@ -94,20 +95,6 @@ public class HockeyappApplication implements Describable<HockeyappApplication> {
         return new DescriptorImpl();
     }
 
-    public static class OldVersionHolder {
-        private String numberOldVersions;
-        // Defaults per https://support.hockeyapp.net/kb/api/api-versions#delete-multiple-versions
-        private String sortOldVersions = "version";
-        private String strategyOldVersions = "purge";
-
-        @DataBoundConstructor
-        public OldVersionHolder(String numberOldVersions, String sortOldVersions, String strategyOldVersions) {
-            this.numberOldVersions = Util.fixEmptyAndTrim(numberOldVersions);
-            this.sortOldVersions = Util.fixEmptyAndTrim(sortOldVersions);
-            this.strategyOldVersions = Util.fixEmptyAndTrim(strategyOldVersions);
-        }
-    }
-
     @Extension
     public static final class DescriptorImpl extends Descriptor<HockeyappApplication> {
         @Override
@@ -142,7 +129,6 @@ public class HockeyappApplication implements Describable<HockeyappApplication> {
             }
             return uploadMethods;
         }
-
 
         @SuppressWarnings("unused")
         public FormValidation doCheckApiToken(@QueryParameter String value) throws IOException, ServletException {

--- a/src/main/java/hockeyapp/HockeyappRecorderConverter.java
+++ b/src/main/java/hockeyapp/HockeyappRecorderConverter.java
@@ -9,6 +9,7 @@ import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
 import hudson.Util;
 import jenkins.model.Jenkins;
+import net.hockeyapp.jenkins.OldVersionHolder;
 import net.hockeyapp.jenkins.RadioButtonSupport;
 import net.hockeyapp.jenkins.releaseNotes.ChangelogReleaseNotes;
 import net.hockeyapp.jenkins.releaseNotes.FileReleaseNotes;
@@ -81,7 +82,7 @@ public class HockeyappRecorderConverter implements Converter {
         public String baseUrl;
         public RadioButtonSupport releaseNotesMethod;
         public boolean failGracefully;
-        public HockeyappApplication.OldVersionHolder oldVersionHolder;
+        public OldVersionHolder oldVersionHolder;
 
         public HockeyappRecorderObsolete() {
             super();
@@ -115,7 +116,7 @@ public class HockeyappRecorderConverter implements Converter {
 
             if (oldVersionHolder == null) {
                 oldVersionHolder =
-                        new HockeyappApplication.OldVersionHolder(Util.fixEmptyAndTrim(numberOldVersions), Util.fixEmptyAndTrim(sortOldVersions), Util.fixEmptyAndTrim(strategyOldVersions));
+                        new OldVersionHolder(Util.fixEmptyAndTrim(numberOldVersions), Util.fixEmptyAndTrim(sortOldVersions), Util.fixEmptyAndTrim(strategyOldVersions));
             }
 
             return this;

--- a/src/main/java/net/hockeyapp/jenkins/OldVersionHolder.java
+++ b/src/main/java/net/hockeyapp/jenkins/OldVersionHolder.java
@@ -1,0 +1,51 @@
+package net.hockeyapp.jenkins;
+
+import hudson.Extension;
+import hudson.ExtensionPoint;
+import hudson.Util;
+import hudson.model.Describable;
+import hudson.model.Descriptor;
+import hudson.model.Saveable;
+import jenkins.model.Jenkins;
+import net.hockeyapp.jenkins.uploadMethod.VersionCreation;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
+
+@ExportedBean
+public class OldVersionHolder implements ExtensionPoint, Describable<OldVersionHolder> {
+
+    @Exported
+    public String numberOldVersions;
+    // Defaults per https://support.hockeyapp.net/kb/api/api-versions#delete-multiple-versions
+    @Exported
+    public String sortOldVersions = "version";
+    @Exported
+    public String strategyOldVersions = "purge";
+
+    @DataBoundConstructor
+    public OldVersionHolder(String numberOldVersions, String sortOldVersions, String strategyOldVersions) {
+        this.numberOldVersions = Util.fixEmptyAndTrim(numberOldVersions);
+        this.sortOldVersions = Util.fixEmptyAndTrim(sortOldVersions);
+        this.strategyOldVersions = Util.fixEmptyAndTrim(strategyOldVersions);
+    }
+
+    @Override
+    public Descriptor<OldVersionHolder> getDescriptor() {
+        return Jenkins.getInstance() == null ? null : Jenkins.getInstance().getDescriptorOrDie(this.getClass());
+    }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<OldVersionHolder> implements Saveable {
+
+        public DescriptorImpl() {
+            super();
+            load();
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Old Version Holder";
+        }
+    }
+}

--- a/src/main/java/net/hockeyapp/jenkins/uploadMethod/VersionCreation.java
+++ b/src/main/java/net/hockeyapp/jenkins/uploadMethod/VersionCreation.java
@@ -2,6 +2,7 @@ package net.hockeyapp.jenkins.uploadMethod;
 
 import hudson.Extension;
 import hudson.Util;
+import hudson.model.Describable;
 import hudson.model.Descriptor;
 import hudson.util.FormValidation;
 import jenkins.model.Jenkins;


### PR DESCRIPTION
I've attempted to fix an issue where it wasn't possible to specify a non-default OldVersionHolder in a Jenkins pipeline job.

To be completely honest, I didn't know anything about writing Jenkins plugins before this, so I've probably not done this correctly, in which case please let me know and I'll try and sort it out.

Cheers,
Simon