### PR TITLE
[JENKINS-33310] Support setting HOCKEYAPP_INSTALL_URL for Pipelines

### DIFF
--- a/src/main/java/hockeyapp/HockeyappRecorder.java
+++ b/src/main/java/hockeyapp/HockeyappRecorder.java
@@ -767,6 +767,10 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
             if (data != null) env.putAll(data);
         }
 
+        public void buildEnvironment(@Nonnull Run<?, ?> build, @Nonnull EnvVars env) {
+            if (data != null) env.putAll(data);
+        }
+
         public String getIconFileName() {
             return null;
         }


### PR DESCRIPTION
HOCKEYAPP_INSTALL_URL and HOCKEYAPP_CONFIG_URL are not set for Pipelines because the appropriate interface is not implemented. Implement that.

Original PR: https://github.com/jenkinsci/hockeyapp-plugin/pull/22

In scope of JENKINS-33310