### PR TITLE
Stop NullPointerException when Username & Password are not set for Proxy

### DIFF
--- a/src/main/java/hockeyapp/HockeyappRecorder.java
+++ b/src/main/java/hockeyapp/HockeyappRecorder.java
@@ -156,7 +156,8 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
 
             ProxyConfiguration configuration = Hudson.getInstance().proxy;
 
-            if (configuration.getUserName() != null && !configuration.getUserName().isEmpty()) {
+            if (configuration.getUserName() != null && !configuration.getUserName().isEmpty()
+                    && configuration.getPassword() != null && !configuration.getPassword().isEmpty()) {
                 Credentials credentials = new UsernamePasswordCredentials(configuration.getUserName(), configuration.getPassword());
                 CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
                 credentialsProvider.setCredentials(new AuthScope(configuration.name, configuration.port), credentials);


### PR DESCRIPTION
Hello,

I recently discovered when the Proxy Configuration is set and there is **no Username and Password set**, the plugin crashes with a "NullPointerException" due to the HashMap containing a null value.

## Steps to Reproduce
1. Spin up Jenkins.
2. Configure the proxy settings but do not set a username and password.

<img width="896" alt="screenshot 2018-03-13 20 15 17" src="https://user-images.githubusercontent.com/8350259/37367449-4d246630-26fb-11e8-9927-1c55366f077d.png">

3. Make sure there's a file available, then run the plugin on post build.
4. Look at the stack trace pasted below:

```
java.lang.NullPointerException
	at java.util.concurrent.ConcurrentHashMap.putVal(ConcurrentHashMap.java:1011)
	at java.util.concurrent.ConcurrentHashMap.put(ConcurrentHashMap.java:1006)
	at org.apache.http.impl.client.BasicCredentialsProvider.setCredentials(BasicCredentialsProvider.java:61)
	at hockeyapp.HockeyappRecorder.createPreconfiguredHttpClient(HockeyappRecorder.java:165)
	at hockeyapp.HockeyappRecorder.performForApplication(HockeyappRecorder.java:252)
	at hockeyapp.HockeyappRecorder.perform(HockeyappRecorder.java:204)
	at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
	at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:744)
	at hudson.model.AbstractBuild$AbstractBuildExecution.performAllBuildSteps(AbstractBuild.java:690)
	at hudson.model.Build$BuildExecution.post2(Build.java:186)
	at hudson.model.AbstractBuild$AbstractBuildExecution.post(AbstractBuild.java:635)
	at hudson.model.Run.execute(Run.java:1752)
	at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
	at hudson.model.ResourceController.execute(ResourceController.java:97)
	at hudson.model.Executor.run(Executor.java:429)
Build step 'Upload to HockeyApp' marked build as failure
Finished: FAILURE
```

Hopefully this fix is sufficient, I only manually tested it by re-uploading the .hpi with the change.