### PR TITLE
Add symbols to extension points

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,12 +121,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci</groupId>
-            <artifactId>annotation-indexer</artifactId>
-            <version>1.9</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
             <version>9.4.5.v20170502</version>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,11 @@
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>structs</artifactId>
+            <version>1.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>apache-httpcomponents-client-4-api</artifactId>
             <version>4.5.5-2.0</version>
             <scope>compile</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.2</version>
+            <version>1.13</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -102,12 +102,6 @@
 
         <!-- Test Scope deps required to defeat Maven Enforcer's requireUpperBoundDeps -->
 
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>structs</artifactId>
-            <version>1.5</version>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>

--- a/src/main/java/hockeyapp/HockeyappRecorder.java
+++ b/src/main/java/hockeyapp/HockeyappRecorder.java
@@ -44,6 +44,7 @@ import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.params.HttpConnectionParams;
 import org.apache.http.params.HttpParams;
+import org.jenkinsci.Symbol;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -639,6 +640,7 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
         }
     }
 
+    @Symbol("hockeyApp")
     @Extension
     // This indicates to Jenkins that this is an implementation of an extension
     // point.

--- a/src/main/java/net/hockeyapp/jenkins/releaseNotes/ChangelogReleaseNotes.java
+++ b/src/main/java/net/hockeyapp/jenkins/releaseNotes/ChangelogReleaseNotes.java
@@ -22,7 +22,7 @@ public class ChangelogReleaseNotes extends RadioButtonSupport {
         return instance == null ? null : instance.getDescriptorOrDie(this.getClass());
     }
 
-    @Symbol("changelogReleaseNotes")
+    @Symbol("changelog")
     @Extension
     public static class DescriptorImpl extends RadioButtonSupportDescriptor<ChangelogReleaseNotes> {
 

--- a/src/main/java/net/hockeyapp/jenkins/releaseNotes/ChangelogReleaseNotes.java
+++ b/src/main/java/net/hockeyapp/jenkins/releaseNotes/ChangelogReleaseNotes.java
@@ -6,6 +6,7 @@ import jenkins.model.Jenkins;
 import net.hockeyapp.jenkins.RadioButtonSupport;
 import net.hockeyapp.jenkins.RadioButtonSupportDescriptor;
 import net.sf.json.JSONObject;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
@@ -21,6 +22,7 @@ public class ChangelogReleaseNotes extends RadioButtonSupport {
         return instance == null ? null : instance.getDescriptorOrDie(this.getClass());
     }
 
+    @Symbol("changelogReleaseNotes")
     @Extension
     public static class DescriptorImpl extends RadioButtonSupportDescriptor<ChangelogReleaseNotes> {
 

--- a/src/main/java/net/hockeyapp/jenkins/releaseNotes/FileReleaseNotes.java
+++ b/src/main/java/net/hockeyapp/jenkins/releaseNotes/FileReleaseNotes.java
@@ -46,7 +46,7 @@ public class FileReleaseNotes extends RadioButtonSupport {
         return instance == null ? null : instance.getDescriptorOrDie(this.getClass());
     }
 
-    @Symbol("fileReleaseNotes")
+    @Symbol("file")
     @Extension
     public static class DescriptorImpl extends RadioButtonSupportDescriptor<FileReleaseNotes> {
 

--- a/src/main/java/net/hockeyapp/jenkins/releaseNotes/FileReleaseNotes.java
+++ b/src/main/java/net/hockeyapp/jenkins/releaseNotes/FileReleaseNotes.java
@@ -7,6 +7,7 @@ import hudson.util.FormValidation;
 import jenkins.model.Jenkins;
 import net.hockeyapp.jenkins.RadioButtonSupport;
 import net.hockeyapp.jenkins.RadioButtonSupportDescriptor;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.export.Exported;
@@ -45,6 +46,7 @@ public class FileReleaseNotes extends RadioButtonSupport {
         return instance == null ? null : instance.getDescriptorOrDie(this.getClass());
     }
 
+    @Symbol("fileReleaseNotes")
     @Extension
     public static class DescriptorImpl extends RadioButtonSupportDescriptor<FileReleaseNotes> {
 

--- a/src/main/java/net/hockeyapp/jenkins/releaseNotes/ManualReleaseNotes.java
+++ b/src/main/java/net/hockeyapp/jenkins/releaseNotes/ManualReleaseNotes.java
@@ -7,6 +7,7 @@ import hudson.util.FormValidation;
 import jenkins.model.Jenkins;
 import net.hockeyapp.jenkins.RadioButtonSupport;
 import net.hockeyapp.jenkins.RadioButtonSupportDescriptor;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.export.Exported;
@@ -45,6 +46,8 @@ public class ManualReleaseNotes extends RadioButtonSupport {
         return instance == null ? null : instance.getDescriptorOrDie(this.getClass());
     }
 
+
+    @Symbol("manualReleaseNotes")
     @Extension
     public static class DescriptorImpl extends RadioButtonSupportDescriptor<ManualReleaseNotes> {
 

--- a/src/main/java/net/hockeyapp/jenkins/releaseNotes/ManualReleaseNotes.java
+++ b/src/main/java/net/hockeyapp/jenkins/releaseNotes/ManualReleaseNotes.java
@@ -47,7 +47,7 @@ public class ManualReleaseNotes extends RadioButtonSupport {
     }
 
 
-    @Symbol("manualReleaseNotes")
+    @Symbol("manual")
     @Extension
     public static class DescriptorImpl extends RadioButtonSupportDescriptor<ManualReleaseNotes> {
 

--- a/src/main/java/net/hockeyapp/jenkins/releaseNotes/NoReleaseNotes.java
+++ b/src/main/java/net/hockeyapp/jenkins/releaseNotes/NoReleaseNotes.java
@@ -22,7 +22,7 @@ public class NoReleaseNotes extends RadioButtonSupport {
         return instance == null ? null : instance.getDescriptorOrDie(this.getClass());
     }
 
-    @Symbol("noReleaseNotes")
+    @Symbol("none")
     @Extension
     public static class DescriptorImpl extends RadioButtonSupportDescriptor<NoReleaseNotes> {
 

--- a/src/main/java/net/hockeyapp/jenkins/releaseNotes/NoReleaseNotes.java
+++ b/src/main/java/net/hockeyapp/jenkins/releaseNotes/NoReleaseNotes.java
@@ -6,6 +6,7 @@ import jenkins.model.Jenkins;
 import net.hockeyapp.jenkins.RadioButtonSupport;
 import net.hockeyapp.jenkins.RadioButtonSupportDescriptor;
 import net.sf.json.JSONObject;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
@@ -21,6 +22,7 @@ public class NoReleaseNotes extends RadioButtonSupport {
         return instance == null ? null : instance.getDescriptorOrDie(this.getClass());
     }
 
+    @Symbol("noReleaseNotes")
     @Extension
     public static class DescriptorImpl extends RadioButtonSupportDescriptor<NoReleaseNotes> {
 

--- a/src/main/java/net/hockeyapp/jenkins/uploadMethod/AppCreation.java
+++ b/src/main/java/net/hockeyapp/jenkins/uploadMethod/AppCreation.java
@@ -6,6 +6,7 @@ import jenkins.model.Jenkins;
 import net.hockeyapp.jenkins.RadioButtonSupport;
 import net.hockeyapp.jenkins.RadioButtonSupportDescriptor;
 import net.sf.json.JSONObject;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.export.Exported;
@@ -25,6 +26,7 @@ public class AppCreation extends RadioButtonSupport {
         return instance == null ? null : instance.getDescriptorOrDie(this.getClass());
     }
 
+    @Symbol("appCreation")
     @Extension
     public static class DescriptorImpl extends RadioButtonSupportDescriptor<AppCreation> {
 

--- a/src/main/java/net/hockeyapp/jenkins/uploadMethod/VersionCreation.java
+++ b/src/main/java/net/hockeyapp/jenkins/uploadMethod/VersionCreation.java
@@ -7,6 +7,7 @@ import hudson.util.FormValidation;
 import jenkins.model.Jenkins;
 import net.hockeyapp.jenkins.RadioButtonSupport;
 import net.hockeyapp.jenkins.RadioButtonSupportDescriptor;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.export.Exported;
@@ -33,6 +34,7 @@ public class VersionCreation extends RadioButtonSupport {
         return instance == null ? null : instance.getDescriptorOrDie(this.getClass());
     }
 
+    @Symbol("versionCreation")
     @Extension
     public static class DescriptorImpl extends RadioButtonSupportDescriptor<VersionCreation> {
 


### PR DESCRIPTION
The PR allows easier pipeline syntax instead of referring to the General Build Step and targetting the plugin class you can now do something similar to:

```
hockeyApp applications: [[downloadAllowed: false, mandatory: true, notifyTeam: true, releaseNotesMethod: changelogReleaseNotes(), uploadMethod: appCreation(false)]], debugMode: false, failGracefully: false
```
We are still targeting Jenkins 1.x hence the need to declare structs explicitly (if I understand correctly).