### PR TITLE
[JENKINS-51982] Do not create install URL

### DIFF
--- a/src/main/java/hockeyapp/HockeyappRecorder.java
+++ b/src/main/java/hockeyapp/HockeyappRecorder.java
@@ -335,21 +335,6 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
                     EnvAction envData = new EnvAction();
                     int appIndex = applications.indexOf(application);
 
-                    String publicUrl = (String) parsedMap.get("public_url");
-                    if (publicUrl != null) {
-                        String installUrl = publicUrl + "/app_versions/" + buildId;
-                        installAction.displayName = Messages.HOCKEYAPP_INSTALL_LINK();
-                        installAction.iconFileName = "package.gif";
-                        installAction.urlName = installUrl;
-                        build.addAction(installAction);
-
-                        if (appIndex == 0) {
-                            envData.add("HOCKEYAPP_INSTALL_URL", installUrl);
-                        }
-
-                        envData.add("HOCKEYAPP_INSTALL_URL_" + appIndex, installUrl);
-                    }
-
                     HockeyappBuildAction configureAction = new HockeyappBuildAction();
                     String configUrl = (String) parsedMap.get("config_url");
                     configureAction.displayName = Messages.HOCKEYAPP_CONFIG_LINK();
@@ -362,6 +347,22 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
                     }
 
                     envData.add("HOCKEYAPP_CONFIG_URL_" + appIndex, configUrl);
+
+                    String publicUrl = (String) parsedMap.get("public_url");
+                    if (publicUrl != null) {
+                        final String appVersion = configUrl.substring(configUrl.indexOf("/app_versions/"));
+                        String installUrl = publicUrl + appVersion;
+                        installAction.displayName = Messages.HOCKEYAPP_INSTALL_LINK();
+                        installAction.iconFileName = "package.gif";
+                        installAction.urlName = installUrl;
+                        build.addAction(installAction);
+
+                        if (appIndex == 0) {
+                            envData.add("HOCKEYAPP_INSTALL_URL", installUrl);
+                        }
+
+                        envData.add("HOCKEYAPP_INSTALL_URL_" + appIndex, installUrl);
+                    }
 
                     build.addAction(envData);
 

--- a/src/main/java/hockeyapp/HockeyappRecorder.java
+++ b/src/main/java/hockeyapp/HockeyappRecorder.java
@@ -332,12 +332,23 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
                     String buildId = Long.toString((Long) parsedMap.get("id"));
 
                     HockeyappBuildAction installAction = new HockeyappBuildAction();
-                    String installUrl = (String) parsedMap.get("public_url") +
-                            "/app_versions/" + buildId;
-                    installAction.displayName = Messages.HOCKEYAPP_INSTALL_LINK();
-                    installAction.iconFileName = "package.gif";
-                    installAction.urlName = installUrl;
-                    build.addAction(installAction);
+                    EnvAction envData = new EnvAction();
+                    int appIndex = applications.indexOf(application);
+
+                    String publicUrl = (String) parsedMap.get("public_url");
+                    if (publicUrl != null) {
+                        String installUrl = publicUrl + "/app_versions/" + buildId;
+                        installAction.displayName = Messages.HOCKEYAPP_INSTALL_LINK();
+                        installAction.iconFileName = "package.gif";
+                        installAction.urlName = installUrl;
+                        build.addAction(installAction);
+
+                        if (appIndex == 0) {
+                            envData.add("HOCKEYAPP_INSTALL_URL", installUrl);
+                        }
+
+                        envData.add("HOCKEYAPP_INSTALL_URL_" + appIndex, installUrl);
+                    }
 
                     HockeyappBuildAction configureAction = new HockeyappBuildAction();
                     String configUrl = (String) parsedMap.get("config_url");
@@ -346,18 +357,13 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
                     configureAction.urlName = configUrl;
                     build.addAction(configureAction);
 
-                    int appIndex = applications.indexOf(application);
-
-                    EnvAction envData = new EnvAction();
-                    build.addAction(envData);
-
                     if (appIndex == 0) {
-                        envData.add("HOCKEYAPP_INSTALL_URL", installUrl);
                         envData.add("HOCKEYAPP_CONFIG_URL", configUrl);
                     }
 
-                    envData.add("HOCKEYAPP_INSTALL_URL_" + appIndex, installUrl);
                     envData.add("HOCKEYAPP_CONFIG_URL_" + appIndex, configUrl);
+
+                    build.addAction(envData);
 
                     String appId;
                     if (application.getNumberOldVersions() != null) {

--- a/src/test/java/hockeyapp/FreestyleTest.java
+++ b/src/test/java/hockeyapp/FreestyleTest.java
@@ -23,7 +23,8 @@ public class FreestyleTest extends ProjectTest {
     private FreeStyleProject project;
 
     @SuppressWarnings("ConstantConditions")
-    @Before public void before() throws Exception {
+    @Before
+    public void before() throws Exception {
         super.before();
         project = jenkinsRule.createFreeStyleProject();
         project.getBuildersList().add(new TestBuilder() {
@@ -31,13 +32,14 @@ public class FreestyleTest extends ProjectTest {
                                    Launcher launcher,
                                    BuildListener listener)
                     throws InterruptedException, IOException {
-                build.getWorkspace().child(FILE_PATH).write(IPA_CONTENTS,"UTF-8");
+                build.getWorkspace().child(FILE_PATH).write(IPA_CONTENTS, "UTF-8");
                 return true;
             }
         });
     }
 
-    @Test public void testFreestyleBuild() throws Exception {
+    @Test
+    public void testFreestyleBuild() throws Exception {
         HockeyappRecorder hockeyappRecorder = new HockeyappRecorderBuilder()
                 .setLocalhostBaseUrl(mockHockeyAppServer.port())
                 .setApplications(Collections.singletonList(new HockeyappApplicationBuilder().create()))
@@ -57,7 +59,8 @@ public class FreestyleTest extends ProjectTest {
         failOnUnmatchedRequests();
     }
 
-    @Test public void testFreestyleBuildWithOldVersionHolder() throws Exception {
+    @Test
+    public void testFreestyleBuildWithOldVersionHolder() throws Exception {
         HockeyappRecorder hockeyappRecorder = new HockeyappRecorderBuilder()
                 .setLocalhostBaseUrl(mockHockeyAppServer.port())
                 .setApplications(Collections.singletonList(
@@ -86,7 +89,8 @@ public class FreestyleTest extends ProjectTest {
         failOnUnmatchedRequests();
     }
 
-    @Test public void testFreestyleBuildWithManualReleaseNotes() throws Exception {
+    @Test
+    public void testFreestyleBuildWithManualReleaseNotes() throws Exception {
         HockeyappRecorder hockeyappRecorder = new HockeyappRecorderBuilder()
                 .setLocalhostBaseUrl(mockHockeyAppServer.port())
                 .setApplications(Collections.singletonList(

--- a/src/test/java/hockeyapp/FreestyleTest.java
+++ b/src/test/java/hockeyapp/FreestyleTest.java
@@ -115,4 +115,67 @@ public class FreestyleTest extends ProjectTest {
         failOnUnmatchedRequests();
     }
 
+    @Test
+    public void should_CreateConfigurationAction_When_BuildEndsInSuccess() throws Exception {
+        // Given
+        HockeyappRecorder hockeyappRecorder = new HockeyappRecorderBuilder()
+                .setLocalhostBaseUrl(mockHockeyAppServer.port())
+                .setApplications(Collections.singletonList(
+                        new HockeyappApplicationBuilder()
+                                .setReleaseNotesMethod(new ManualReleaseNotes("releaseNotes", false))
+                                .create()))
+                .create();
+        project.getPublishersList().add(hockeyappRecorder);
+
+        // When
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
+
+        // Then
+        assertBuildSuccessful(build);
+        assertConfigurationLinkActionIsCreated(build);
+        failOnUnmatchedRequests();
+    }
+
+    @Test
+    public void should_CreateInstallationAction_When_BuildEndsInSuccess() throws Exception {
+        // Given
+        HockeyappRecorder hockeyappRecorder = new HockeyappRecorderBuilder()
+                .setLocalhostBaseUrl(mockHockeyAppServer.port())
+                .setApplications(Collections.singletonList(
+                        new HockeyappApplicationBuilder()
+                                .setReleaseNotesMethod(new ManualReleaseNotes("releaseNotes", false))
+                                .create()))
+                .create();
+        project.getPublishersList().add(hockeyappRecorder);
+
+        // When
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
+
+        // Then
+        assertBuildSuccessful(build);
+        assertInstallationLinkActionIsCreated(build);
+        failOnUnmatchedRequests();
+    }
+
+    @Test
+    public void should_Not_CreateInstallationAction_When_APIKeyHasNoPermissionToRelease() throws Exception {
+        // Given
+        apiKeyHasNoUploadPermission();
+        HockeyappRecorder hockeyappRecorder = new HockeyappRecorderBuilder()
+                .setLocalhostBaseUrl(mockHockeyAppServer.port())
+                .setApplications(Collections.singletonList(
+                        new HockeyappApplicationBuilder()
+                                .setReleaseNotesMethod(new ManualReleaseNotes("releaseNotes", false))
+                                .create()))
+                .create();
+        project.getPublishersList().add(hockeyappRecorder);
+
+        // When
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
+
+        // Then
+        assertBuildSuccessful(build);
+        assertInstallationLinkActionIsNotCreated(build);
+        failOnUnmatchedRequests();
+    }
 }

--- a/src/test/java/hockeyapp/ProjectTest.java
+++ b/src/test/java/hockeyapp/ProjectTest.java
@@ -36,7 +36,28 @@ public abstract class ProjectTest {
                 .willReturn(aResponse()
                         .withHeader("Content-Type", "application/json")
                         .withStatus(201)
-                        .withBody("{\"id\": 3702837409, \"public URL\": \"foobar\", \"public_identifier\": \"" + APP_ID + "\" }")));
+                        .withBody("{\n" +
+                                "  \"title\": \"Android\",\n" +
+                                "  \"bundle_identifier\": \"net.hockeyapp.jenkins.android\",\n" +
+                                "  \"public_identifier\": \"" + APP_ID + "\",\n" +
+                                "  \"platform\": \"Android\",\n" +
+                                "  \"release_type\": 0,\n" +
+                                "  \"custom_release_type\": null,\n" +
+                                "  \"created_at\": \"2018-06-16T21:16:48Z\",\n" +
+                                "  \"updated_at\": \"2018-06-16T21:16:51Z\",\n" +
+                                "  \"featured\": false,\n" +
+                                "  \"role\": 0,\n" +
+                                "  \"id\": 788014,\n" +
+                                "  \"config_url\": \"https://rink.hockeyapp.net/manage/apps/bar/app_versions/1\",\n" +
+                                "  \"public_url\": \"https://rink.hockeyapp.net/apps/foo\",\n" +
+                                "  \"minimum_os_version\": \"5.0\",\n" +
+                                "  \"device_family\": null,\n" +
+                                "  \"status\": 2,\n" +
+                                "  \"visibility\": \"private\",\n" +
+                                "  \"owner\": \"Foo Bar Inc\",\n" +
+                                "  \"owner_token\": \"bar-baz\",\n" +
+                                "  \"retention_days\": \"90\"\n" +
+                                "}")));
         mockHockeyAppServer.stubFor(post(urlEqualTo(HOCKEY_APP_DELETE_URL))
                 .willReturn(aResponse()
                         .withStatus(204)));

--- a/src/test/java/hockeyapp/ProjectTest.java
+++ b/src/test/java/hockeyapp/ProjectTest.java
@@ -3,19 +3,21 @@ package hockeyapp;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.matching.StringValuePattern;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import hudson.model.Action;
 import hudson.model.Run;
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.jvnet.hudson.test.JenkinsRule;
 
+import java.util.Collections;
 import java.util.List;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static hockeyapp.builder.HockeyappApplicationBuilder.FILE_PATH;
+import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.StringContains.containsString;
 
 public abstract class ProjectTest {
 
@@ -63,6 +65,34 @@ public abstract class ProjectTest {
                         .withStatus(204)));
     }
 
+    void apiKeyHasNoUploadPermission() {
+        mockHockeyAppServer.stubFor(post(urlEqualTo(HOCKEY_APP_UPLOAD_URL))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withStatus(201)
+                        .withBody("{\n" +
+                                "  \"title\": \"Android\",\n" +
+                                "  \"bundle_identifier\": \"net.hockeyapp.jenkins.android\",\n" +
+                                "  \"public_identifier\": \"" + APP_ID + "\",\n" +
+                                "  \"platform\": \"Android\",\n" +
+                                "  \"release_type\": 0,\n" +
+                                "  \"custom_release_type\": null,\n" +
+                                "  \"created_at\": \"2018-06-16T21:16:48Z\",\n" +
+                                "  \"updated_at\": \"2018-06-16T21:16:51Z\",\n" +
+                                "  \"featured\": false,\n" +
+                                "  \"role\": 0,\n" +
+                                "  \"id\": 788014,\n" +
+                                "  \"config_url\": \"https://rink.hockeyapp.net/manage/apps/bar/app_versions/1\",\n" +
+                                "  \"minimum_os_version\": \"5.0\",\n" +
+                                "  \"device_family\": null,\n" +
+                                "  \"status\": 2,\n" +
+                                "  \"visibility\": \"private\",\n" +
+                                "  \"owner\": \"Foo Bar Inc\",\n" +
+                                "  \"owner_token\": \"bar-baz\",\n" +
+                                "  \"retention_days\": \"90\"\n" +
+                                "}")));
+    }
+
     void failOnUnmatchedRequests() throws Exception {
         List<LoggedRequest> unmatchedRequests = mockHockeyAppServer.findUnmatchedRequests().getRequests();
         if (unmatchedRequests.size() != 0) {
@@ -75,6 +105,39 @@ public abstract class ProjectTest {
         assertThat(log, containsString("Uploading to HockeyApp..."));
         assertThat(log, containsString(FILE_PATH));
         jenkinsRule.assertBuildStatusSuccess(build);
+    }
+
+    void assertConfigurationLinkActionIsCreated(Run build) {
+        final List<? extends Action> allActions = build != null ? build.getAllActions() : Collections.<Action>emptyList();
+        boolean test = false;
+        for (Action action : allActions) {
+            if (action instanceof HockeyappBuildAction && action.getDisplayName().contentEquals(Messages.HOCKEYAPP_CONFIG_LINK())) {
+                test = true;
+            }
+        }
+        assertThat(test, is(true));
+    }
+
+    void assertInstallationLinkActionIsNotCreated(Run build) {
+        final List<? extends Action> allActions = build != null ? build.getAllActions() : Collections.<Action>emptyList();
+        boolean test = false;
+        for (Action action : allActions) {
+            if (action instanceof HockeyappBuildAction && action.getDisplayName().contentEquals(Messages.HOCKEYAPP_INSTALL_LINK())) {
+                test = true;
+            }
+        }
+        assertThat(test, is(not((true))));
+    }
+
+    void assertInstallationLinkActionIsCreated(Run build) {
+        final List<? extends Action> allActions = build != null ? build.getAllActions() : Collections.<Action>emptyList();
+        boolean test = false;
+        for (Action action : allActions) {
+            if (action instanceof HockeyappBuildAction && action.getDisplayName().contentEquals(Messages.HOCKEYAPP_INSTALL_LINK())) {
+                test = true;
+            }
+        }
+        assertThat(test, is(true));
     }
 
     StringValuePattern releaseNotesTypeFormData() {

--- a/src/test/java/hockeyapp/ProjectTest.java
+++ b/src/test/java/hockeyapp/ProjectTest.java
@@ -1,9 +1,7 @@
 package hockeyapp;
 
-import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.matching.StringValuePattern;
-import com.github.tomakehurst.wiremock.verification.FindRequestsResult;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import hudson.model.Run;
 import org.apache.commons.io.FileUtils;
@@ -27,8 +25,10 @@ public abstract class ProjectTest {
     static final String HOCKEY_APP_UPLOAD_URL = "/api/2/apps/upload";
     static final String HOCKEY_APP_DELETE_URL = "/api/2/apps/" + APP_ID + "/app_versions/delete";
 
-    @Rule public JenkinsRule jenkinsRule = new JenkinsRule();
-    @Rule public WireMockRule mockHockeyAppServer = new WireMockRule(options().dynamicPort());
+    @Rule
+    public JenkinsRule jenkinsRule = new JenkinsRule();
+    @Rule
+    public WireMockRule mockHockeyAppServer = new WireMockRule(options().dynamicPort());
 
     @Before
     public void before() throws Exception {


### PR DESCRIPTION
If public_url not available typically because we are using an API key
that has insufficient permissions to create releases. In this scenario `installUrl` resolves to `null/app_versions/{buildId}` which makes no sense to be creating.

@jenkinsci/code-reviewers would you do the honours, please. Thanks.