### PR TITLE
Add support for uploading multiple builds to the same version

### DIFF
--- a/src/main/java/hockeyapp/HockeyappRecorder.java
+++ b/src/main/java/hockeyapp/HockeyappRecorder.java
@@ -34,7 +34,9 @@ import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
 import org.apache.http.conn.params.ConnRoutePNames;
 import org.apache.http.entity.mime.MultipartEntity;
 import org.apache.http.entity.mime.content.FileBody;
@@ -269,17 +271,19 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
                         return this.failGracefully;
                     }
 
-                    String path = createPath(logger, vars, application);
+                    HttpInfo info = getHttpInfo(logger, vars, application);
+                    String path = info.getPath();
                     URL host = createHostUrl(vars);
                     URL url = new URL(host, path);
 
                     HttpClient httpclient = createPreconfiguredHttpClient(url, logger);
 
-                    HttpPost httpPost = new HttpPost(url.toURI());
-
+                    HttpEntityEnclosingRequestBase httpRequest = info.getMethod() == HttpMethod.PUT
+                            ? new HttpPut(url.toURI())
+                            : new HttpPost(url.toURI());
 
                     FileBody fileBody = new FileBody(file);
-                    httpPost.setHeader("X-HockeyAppToken", vars.expand(fetchApiToken(application)));
+                    httpRequest.setHeader("X-HockeyAppToken", vars.expand(fetchApiToken(application)));
                     MultipartEntity entity = new MultipartEntity();
 
                     if (application.releaseNotesMethod != null) {
@@ -329,10 +333,10 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
                         AppCreation appCreation = (AppCreation) application.uploadMethod;
                         entity.addPart("private", new StringBody(appCreation.publicPage ? "false" : "true"));
                     }
-                    httpPost.setEntity(entity);
+                    httpRequest.setEntity(entity);
 
                     long startTime = System.currentTimeMillis();
-                    HttpResponse response = httpclient.execute(httpPost);
+                    HttpResponse response = httpclient.execute(httpRequest);
                     long duration = System.currentTimeMillis() - startTime;
 
                     printUploadSpeed(duration, fileSize, logger);
@@ -440,20 +444,26 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
 
     }
 
-    private String createPath(PrintStream logger, EnvVars vars, HockeyappApplication application) {
-        String path;
+    private HttpInfo getHttpInfo(PrintStream logger, EnvVars vars, HockeyappApplication application) {
+        HttpInfo info = new HttpInfo();
         if (application.uploadMethod instanceof VersionCreation) {
             VersionCreation versionCreation = (VersionCreation) application.uploadMethod;
             if (versionCreation.getAppId() != null && !vars.expand(versionCreation.getAppId()).isEmpty()) {
-                path = "/api/2/apps/" + vars.expand(versionCreation.getAppId()) + "/app_versions/upload";
+                info.setPath("/api/2/apps/" + vars.expand(versionCreation.getAppId()) + "/app_versions/");
+                if (versionCreation.getVersionCode() != null && !vars.expand(versionCreation.getVersionCode()).isEmpty()) {
+                    info.setPath(info.getPath() + vars.expand(versionCreation.getVersionCode()));
+                    info.setMethod(HttpMethod.PUT);
+                } else {
+                    info.setPath(info.getPath() + "upload");
+                }
             } else {
                 logger.println("No AppId specified!");
-                path = null;
+                info.setPath(null);
             }
         } else {
-            path = "/api/2/apps/upload";
+            info.setPath("/api/2/apps/upload");
         }
-        return path;
+        return info;
     }
 
 
@@ -662,6 +672,10 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
         return true;
     }
 
+    public enum HttpMethod {
+        POST, PUT
+    }
+
     public static class BaseUrlHolder {
 
         private String baseUrl;
@@ -810,4 +824,29 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
             return null;
         }
     }
+
+    private static class HttpInfo {
+        private String path;
+        private HttpMethod method = HttpMethod.POST;
+
+        HttpInfo() {
+        }
+
+        public String getPath() {
+            return path;
+        }
+
+        public void setPath(String path) {
+            this.path = path;
+        }
+
+        public HttpMethod getMethod() {
+            return method;
+        }
+
+        public void setMethod(HttpMethod method) {
+            this.method = method;
+        }
+    }
+
 }

--- a/src/main/java/hockeyapp/HockeyappRecorder.java
+++ b/src/main/java/hockeyapp/HockeyappRecorder.java
@@ -278,7 +278,7 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
 
                     HttpClient httpclient = createPreconfiguredHttpClient(url, logger);
 
-                    HttpEntityEnclosingRequestBase httpRequest = info.getMethod() == HttpMethod.PUT
+                    HttpEntityEnclosingRequestBase httpRequest = info.getMethod().equals(HttpPut.METHOD_NAME)
                             ? new HttpPut(url.toURI())
                             : new HttpPost(url.toURI());
 
@@ -452,7 +452,7 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
                 info.setPath("/api/2/apps/" + vars.expand(versionCreation.getAppId()) + "/app_versions/");
                 if (versionCreation.getVersionCode() != null && !vars.expand(versionCreation.getVersionCode()).isEmpty()) {
                     info.setPath(info.getPath() + vars.expand(versionCreation.getVersionCode()));
-                    info.setMethod(HttpMethod.PUT);
+                    info.setMethod(HttpPut.METHOD_NAME);
                 } else {
                     info.setPath(info.getPath() + "upload");
                 }
@@ -672,10 +672,6 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
         return true;
     }
 
-    public enum HttpMethod {
-        POST, PUT
-    }
-
     public static class BaseUrlHolder {
 
         private String baseUrl;
@@ -822,30 +818,6 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
 
         public String getUrlName() {
             return null;
-        }
-    }
-
-    private static class HttpInfo {
-        private String path;
-        private HttpMethod method = HttpMethod.POST;
-
-        HttpInfo() {
-        }
-
-        public String getPath() {
-            return path;
-        }
-
-        public void setPath(String path) {
-            this.path = path;
-        }
-
-        public HttpMethod getMethod() {
-            return method;
-        }
-
-        public void setMethod(HttpMethod method) {
-            this.method = method;
         }
     }
 

--- a/src/main/java/hockeyapp/HockeyappRecorderConverter.java
+++ b/src/main/java/hockeyapp/HockeyappRecorderConverter.java
@@ -107,7 +107,7 @@ public class HockeyappRecorderConverter implements Converter {
             appId = Util.fixEmptyAndTrim(appId);
             if (uploadMethod == null) {
                 if (useAppVersionURL && (appId != null)) {
-                    uploadMethod = new VersionCreation(appId);
+                    uploadMethod = new VersionCreation(appId, "");
                 } else {
                     uploadMethod = new AppCreation(false);
                 }

--- a/src/main/java/hockeyapp/HockeyappRecorderConverter.java
+++ b/src/main/java/hockeyapp/HockeyappRecorderConverter.java
@@ -107,7 +107,7 @@ public class HockeyappRecorderConverter implements Converter {
             appId = Util.fixEmptyAndTrim(appId);
             if (uploadMethod == null) {
                 if (useAppVersionURL && (appId != null)) {
-                    uploadMethod = new VersionCreation(appId, "");
+                    uploadMethod = new VersionCreation(appId);
                 } else {
                     uploadMethod = new AppCreation(false);
                 }

--- a/src/main/java/hockeyapp/HttpInfo.java
+++ b/src/main/java/hockeyapp/HttpInfo.java
@@ -1,0 +1,27 @@
+package hockeyapp;
+
+import org.apache.http.client.methods.HttpPost;
+
+class HttpInfo {
+    private String path;
+    private String method = HttpPost.METHOD_NAME;
+
+    HttpInfo() {
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public String getMethod() {
+        return method;
+    }
+
+    public void setMethod(String method) {
+        this.method = method;
+    }
+}

--- a/src/main/java/net/hockeyapp/jenkins/uploadMethod/VersionCreation.java
+++ b/src/main/java/net/hockeyapp/jenkins/uploadMethod/VersionCreation.java
@@ -23,6 +23,11 @@ public class VersionCreation extends RadioButtonSupport {
     @Exported
     private String versionCode;
 
+    @Deprecated
+    public VersionCreation(String appId) {
+        this(appId, null);
+    }
+
     @DataBoundConstructor
     public VersionCreation(String appId, String versionCode) {
         this.appId = Util.fixEmptyAndTrim(appId);

--- a/src/main/java/net/hockeyapp/jenkins/uploadMethod/VersionCreation.java
+++ b/src/main/java/net/hockeyapp/jenkins/uploadMethod/VersionCreation.java
@@ -20,13 +20,21 @@ public class VersionCreation extends RadioButtonSupport {
     @Exported
     private String appId;
 
+    @Exported
+    private String versionCode;
+
     @DataBoundConstructor
-    public VersionCreation(String appId) {
+    public VersionCreation(String appId, String versionCode) {
         this.appId = Util.fixEmptyAndTrim(appId);
+        this.versionCode = Util.fixEmptyAndTrim(versionCode);
     }
 
     public String getAppId() {
         return appId;
+    }
+
+    public String getVersionCode() {
+        return versionCode;
     }
 
     public Descriptor<RadioButtonSupport> getDescriptor() {
@@ -67,6 +75,15 @@ public class VersionCreation extends RadioButtonSupport {
                 return FormValidation.ok();
             }
 
+        }
+
+        @SuppressWarnings("unused")
+        public FormValidation doCheckVersionCode(@QueryParameter String value) throws IOException, ServletException {
+            if (value.matches("[0-9]*") || value.equals("")) {
+                return FormValidation.ok();
+            } else {
+                return FormValidation.warning("Version code should be an integer value >0.");
+            }
         }
     }
 

--- a/src/main/resources/net/hockeyapp/jenkins/uploadMethod/VersionCreation/config.jelly
+++ b/src/main/resources/net/hockeyapp/jenkins/uploadMethod/VersionCreation/config.jelly
@@ -4,4 +4,7 @@
     <f:entry title="${%App ID}" field="appId">
         <f:textbox checkUrl="'descriptorByName/net.hockeyapp.jenkins.uploadMethod.VersionCreation/checkAppId?value='+escape(this.value)"/>
     </f:entry>
+    <f:entry title="${%Version Code (Optional)}" field="versionCode">
+        <f:textbox checkUrl="'descriptorByName/net.hockeyapp.jenkins.uploadMethod.VersionCreation/checkVersionCode?value='+escape(this.value)"/>
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/net/hockeyapp/jenkins/uploadMethod/VersionCreation/config.jelly
+++ b/src/main/resources/net/hockeyapp/jenkins/uploadMethod/VersionCreation/config.jelly
@@ -4,7 +4,7 @@
     <f:entry title="${%App ID}" field="appId">
         <f:textbox checkUrl="'descriptorByName/net.hockeyapp.jenkins.uploadMethod.VersionCreation/checkAppId?value='+escape(this.value)"/>
     </f:entry>
-    <f:entry title="${%Version Code (Optional)}" field="versionCode">
+    <f:entry title="${%App Version (Optional)}" field="versionCode">
         <f:textbox checkUrl="'descriptorByName/net.hockeyapp.jenkins.uploadMethod.VersionCreation/checkVersionCode?value='+escape(this.value)"/>
     </f:entry>
 </j:jelly>

--- a/src/main/resources/net/hockeyapp/jenkins/uploadMethod/VersionCreation/help-versionCode.html
+++ b/src/main/resources/net/hockeyapp/jenkins/uploadMethod/VersionCreation/help-versionCode.html
@@ -1,0 +1,4 @@
+<div>
+The version code to upload to. If not set, a new version will be generated<br/>
+Can be found in HockeyApp project settings.
+</div>

--- a/src/test/java/hockeyapp/ProjectTest.java
+++ b/src/test/java/hockeyapp/ProjectTest.java
@@ -25,6 +25,7 @@ public abstract class ProjectTest {
     static final String IPA_CONTENTS = "Lorem Ipsum";
 
     static final String HOCKEY_APP_UPLOAD_URL = "/api/2/apps/upload";
+    static final String HOCKEY_APP_VERSION_UPLOAD_URL = "/api/2/apps/" + APP_ID + "/app_versions/1";
     static final String HOCKEY_APP_DELETE_URL = "/api/2/apps/" + APP_ID + "/app_versions/delete";
 
     @Rule
@@ -35,6 +36,32 @@ public abstract class ProjectTest {
     @Before
     public void before() throws Exception {
         mockHockeyAppServer.stubFor(post(urlEqualTo(HOCKEY_APP_UPLOAD_URL))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withStatus(201)
+                        .withBody("{\n" +
+                                "  \"title\": \"Android\",\n" +
+                                "  \"bundle_identifier\": \"net.hockeyapp.jenkins.android\",\n" +
+                                "  \"public_identifier\": \"" + APP_ID + "\",\n" +
+                                "  \"platform\": \"Android\",\n" +
+                                "  \"release_type\": 0,\n" +
+                                "  \"custom_release_type\": null,\n" +
+                                "  \"created_at\": \"2018-06-16T21:16:48Z\",\n" +
+                                "  \"updated_at\": \"2018-06-16T21:16:51Z\",\n" +
+                                "  \"featured\": false,\n" +
+                                "  \"role\": 0,\n" +
+                                "  \"id\": 788014,\n" +
+                                "  \"config_url\": \"https://rink.hockeyapp.net/manage/apps/bar/app_versions/1\",\n" +
+                                "  \"public_url\": \"https://rink.hockeyapp.net/apps/foo\",\n" +
+                                "  \"minimum_os_version\": \"5.0\",\n" +
+                                "  \"device_family\": null,\n" +
+                                "  \"status\": 2,\n" +
+                                "  \"visibility\": \"private\",\n" +
+                                "  \"owner\": \"Foo Bar Inc\",\n" +
+                                "  \"owner_token\": \"bar-baz\",\n" +
+                                "  \"retention_days\": \"90\"\n" +
+                                "}")));
+        mockHockeyAppServer.stubFor(put(urlEqualTo(HOCKEY_APP_VERSION_UPLOAD_URL))
                 .willReturn(aResponse()
                         .withHeader("Content-Type", "application/json")
                         .withStatus(201)


### PR DESCRIPTION
This PR allows users to specify a version number to upload their builds to. This allows for more than one build to be referenced to the same version. 

The issue initially faced was uploading a new version every build was quickly getting out of hand, and finding specific historic builds (those released to the public) in the app was becoming difficult. Uploading several builds to the same version cuts down on the number of internal versions being shown in-app.