### PR TITLE
[Jenkins-54498] version creation databoundconstructor regression

### DIFF
--- a/src/main/java/hockeyapp/HockeyappRecorder.java
+++ b/src/main/java/hockeyapp/HockeyappRecorder.java
@@ -456,9 +456,13 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
             if (!vars.expand(versionCreation.getAppId()).isEmpty()) {
                 info.setPath("/api/2/apps/" + vars.expand(versionCreation.getAppId()) + "/app_versions/");
                 if (versionCreation.getVersionCode() != null && !vars.expand(versionCreation.getVersionCode()).isEmpty()) {
+                    // Update an existing version
+                    // https://support.hockeyapp.net/kb/api/api-versions#update-version
                     info.setPath(info.getPath() + vars.expand(versionCreation.getVersionCode()));
                     info.setMethod(HttpPut.METHOD_NAME);
                 } else {
+                    // Upload a new version
+                    // https://support.hockeyapp.net/kb/api/api-versions#upload-version
                     info.setPath(info.getPath() + "upload");
                 }
             } else {
@@ -466,6 +470,8 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
                 info.setPath(null);
             }
         } else {
+            // Uploads app and assigns a new version. Only if there is no existing app?
+            // https://support.hockeyapp.net/kb/api/api-apps#upload-app
             info.setPath("/api/2/apps/upload");
         }
         return info;

--- a/src/main/java/hockeyapp/HockeyappRecorder.java
+++ b/src/main/java/hockeyapp/HockeyappRecorder.java
@@ -453,7 +453,7 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
         HttpInfo info = new HttpInfo();
         if (application.uploadMethod instanceof VersionCreation) {
             VersionCreation versionCreation = (VersionCreation) application.uploadMethod;
-            if (versionCreation.getAppId() != null && !vars.expand(versionCreation.getAppId()).isEmpty()) {
+            if (!vars.expand(versionCreation.getAppId()).isEmpty()) {
                 info.setPath("/api/2/apps/" + vars.expand(versionCreation.getAppId()) + "/app_versions/");
                 if (versionCreation.getVersionCode() != null && !vars.expand(versionCreation.getVersionCode()).isEmpty()) {
                     info.setPath(info.getPath() + vars.expand(versionCreation.getVersionCode()));

--- a/src/main/java/net/hockeyapp/jenkins/uploadMethod/VersionCreation.java
+++ b/src/main/java/net/hockeyapp/jenkins/uploadMethod/VersionCreation.java
@@ -65,18 +65,7 @@ public class VersionCreation extends RadioButtonSupport {
         }
 
         @SuppressWarnings("unused")
-        public FormValidation doCheckAppId(@QueryParameter String value) throws IOException, ServletException {
-//            if(value.isEmpty()) {
-//                return FormValidation.error("You must enter an App ID.");
-//            } else if(value.length() != 32) {
-//                return FormValidation.error("App ID length must be 32.");
-//            } else {
-//                if (value.matches("[0-9A-Fa-f]{32}")) {
-//                    return FormValidation.ok();
-//                } else {
-//                    return FormValidation.warning("Check correctness of App ID.");
-//                }
-//            }
+        public FormValidation doCheckAppId(@QueryParameter String value) {
             if (value.isEmpty()) {
                 return FormValidation.error("You must enter an App ID.");
             } else {
@@ -86,7 +75,7 @@ public class VersionCreation extends RadioButtonSupport {
         }
 
         @SuppressWarnings("unused")
-        public FormValidation doCheckVersionCode(@QueryParameter String value) throws IOException, ServletException {
+        public FormValidation doCheckVersionCode(@QueryParameter String value) {
             if (value.matches("[0-9]*") || value.equals("")) {
                 return FormValidation.ok();
             } else {

--- a/src/main/java/net/hockeyapp/jenkins/uploadMethod/VersionCreation.java
+++ b/src/main/java/net/hockeyapp/jenkins/uploadMethod/VersionCreation.java
@@ -9,12 +9,11 @@ import net.hockeyapp.jenkins.RadioButtonSupport;
 import net.hockeyapp.jenkins.RadioButtonSupportDescriptor;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.export.Exported;
 
-import javax.annotation.Nullable;
-import javax.servlet.ServletException;
-import java.io.IOException;
+import javax.annotation.Nonnull;
 
 public class VersionCreation extends RadioButtonSupport {
 
@@ -22,27 +21,25 @@ public class VersionCreation extends RadioButtonSupport {
     private String appId;
 
     @Exported
-    @Nullable
-    private String versionCode = null;
-
-    @Deprecated
-    public VersionCreation(String appId) {
-        this(appId, null);
-    }
+    private String versionCode = "";
 
     @DataBoundConstructor
-    public VersionCreation(String appId, String versionCode) {
+    public VersionCreation(String appId) {
         this.appId = Util.fixEmptyAndTrim(appId);
-        this.versionCode = Util.fixEmptyAndTrim(versionCode);
     }
 
     public String getAppId() {
         return appId;
     }
 
-    @Nullable
+    @Nonnull
     public String getVersionCode() {
         return versionCode;
+    }
+
+    @DataBoundSetter
+    public void setVersionCode(@Nonnull String versionCode) {
+        this.versionCode = Util.fixNull(versionCode);
     }
 
     public Descriptor<RadioButtonSupport> getDescriptor() {

--- a/src/main/java/net/hockeyapp/jenkins/uploadMethod/VersionCreation.java
+++ b/src/main/java/net/hockeyapp/jenkins/uploadMethod/VersionCreation.java
@@ -24,10 +24,11 @@ public class VersionCreation extends RadioButtonSupport {
     private String versionCode = "";
 
     @DataBoundConstructor
-    public VersionCreation(String appId) {
-        this.appId = Util.fixEmptyAndTrim(appId);
+    public VersionCreation(@Nonnull String appId) {
+        this.appId = Util.fixNull(appId);
     }
 
+    @Nonnull
     public String getAppId() {
         return appId;
     }

--- a/src/main/java/net/hockeyapp/jenkins/uploadMethod/VersionCreation.java
+++ b/src/main/java/net/hockeyapp/jenkins/uploadMethod/VersionCreation.java
@@ -30,6 +30,12 @@ public class VersionCreation extends RadioButtonSupport {
         this.appId = Util.fixNull(appId);
     }
 
+    @Deprecated
+    public VersionCreation(@Nonnull String appId, @CheckForNull String versionCode) {
+        this.appId = Util.fixNull(appId);
+        this.versionCode = Util.fixNull(versionCode);
+    }
+
     @Nonnull
     public String getAppId() {
         return appId;

--- a/src/main/java/net/hockeyapp/jenkins/uploadMethod/VersionCreation.java
+++ b/src/main/java/net/hockeyapp/jenkins/uploadMethod/VersionCreation.java
@@ -13,6 +13,7 @@ import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.export.Exported;
 
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
 public class VersionCreation extends RadioButtonSupport {
@@ -21,7 +22,8 @@ public class VersionCreation extends RadioButtonSupport {
     private String appId;
 
     @Exported
-    private String versionCode = "";
+    @CheckForNull
+    private String versionCode;
 
     @DataBoundConstructor
     public VersionCreation(@Nonnull String appId) {
@@ -33,13 +35,13 @@ public class VersionCreation extends RadioButtonSupport {
         return appId;
     }
 
-    @Nonnull
+    @CheckForNull
     public String getVersionCode() {
         return versionCode;
     }
 
     @DataBoundSetter
-    public void setVersionCode(@Nonnull String versionCode) {
+    public void setVersionCode(@CheckForNull String versionCode) {
         this.versionCode = Util.fixNull(versionCode);
     }
 

--- a/src/main/java/net/hockeyapp/jenkins/uploadMethod/VersionCreation.java
+++ b/src/main/java/net/hockeyapp/jenkins/uploadMethod/VersionCreation.java
@@ -12,6 +12,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.export.Exported;
 
+import javax.annotation.Nullable;
 import javax.servlet.ServletException;
 import java.io.IOException;
 
@@ -21,7 +22,8 @@ public class VersionCreation extends RadioButtonSupport {
     private String appId;
 
     @Exported
-    private String versionCode;
+    @Nullable
+    private String versionCode = null;
 
     @Deprecated
     public VersionCreation(String appId) {
@@ -38,6 +40,7 @@ public class VersionCreation extends RadioButtonSupport {
         return appId;
     }
 
+    @Nullable
     public String getVersionCode() {
         return versionCode;
     }

--- a/src/test/java/hockeyapp/FreestyleTest.java
+++ b/src/test/java/hockeyapp/FreestyleTest.java
@@ -181,13 +181,13 @@ public class FreestyleTest extends ProjectTest {
     }
 
     @Test
-    public void testFreeStyleBuildWithSameVersion() throws Exception {
+    public void should_UploadAVersionedApp_When_VersionCreationIsSelected_And_VersionIsNotSpecified() throws Exception {
         // Given
         HockeyappRecorder hockeyappRecorder = new HockeyappRecorderBuilder()
                 .setLocalhostBaseUrl(mockHockeyAppServer.port())
                 .setApplications(Collections.singletonList(
                         new HockeyappApplicationBuilder()
-                                .setUploadMethod(new VersionCreation(APP_ID, "1"))
+                                .setUploadMethod(new VersionCreation(APP_ID))
                                 .create()))
                 .create();
         project.getPublishersList().add(hockeyappRecorder);
@@ -197,7 +197,61 @@ public class FreestyleTest extends ProjectTest {
 
         // Then
         assertBuildSuccessful(build);
-        mockHockeyAppServer.verify(1, putRequestedFor(urlEqualTo(HOCKEY_APP_VERSION_UPLOAD_BASE_URL))
+        mockHockeyAppServer.verify(1, postRequestedFor(urlEqualTo(HOCKEY_VERSION_UPLOAD_NEW_URL))
+                .withHeader("Content-Type", containing("multipart/form-data;"))
+                .withRequestBody(ipaFormData())
+                .withRequestBody(mandatoryFormData(0))
+                .withRequestBody(notifyFormData(0))
+                .withRequestBody(statusFormData(1)));
+        failOnUnmatchedRequests();
+    }
+
+    @Test
+    public void should_UploadAVersionedApp_When_VersionCreationIsSelected_And_VersionIsSpecfied_1() throws Exception {
+        // Given
+        final String version = "1";
+        HockeyappRecorder hockeyappRecorder = new HockeyappRecorderBuilder()
+                .setLocalhostBaseUrl(mockHockeyAppServer.port())
+                .setApplications(Collections.singletonList(
+                        new HockeyappApplicationBuilder()
+                                .setUploadMethod(new VersionCreation(APP_ID, version))
+                                .create()))
+                .create();
+        project.getPublishersList().add(hockeyappRecorder);
+
+        // When
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
+
+        // Then
+        assertBuildSuccessful(build);
+        mockHockeyAppServer.verify(1, putRequestedFor(urlEqualTo(HOCKEY_VERSION_UPLOAD_EXISTING_BASE_URL + version))
+                .withHeader("Content-Type", containing("multipart/form-data;"))
+                .withRequestBody(ipaFormData())
+                .withRequestBody(mandatoryFormData(0))
+                .withRequestBody(notifyFormData(0))
+                .withRequestBody(statusFormData(1)));
+        failOnUnmatchedRequests();
+    }
+
+    @Test
+    public void should_UploadAVersionedApp_When_VersionCreationIsSelected_And_VersionIsSpecfied_2() throws Exception {
+        // Given
+        final String version = "2";
+        HockeyappRecorder hockeyappRecorder = new HockeyappRecorderBuilder()
+                .setLocalhostBaseUrl(mockHockeyAppServer.port())
+                .setApplications(Collections.singletonList(
+                        new HockeyappApplicationBuilder()
+                                .setUploadMethod(new VersionCreation(APP_ID, version))
+                                .create()))
+                .create();
+        project.getPublishersList().add(hockeyappRecorder);
+
+        // When
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
+
+        // Then
+        assertBuildSuccessful(build);
+        mockHockeyAppServer.verify(1, putRequestedFor(urlEqualTo(HOCKEY_VERSION_UPLOAD_EXISTING_BASE_URL + version))
                 .withHeader("Content-Type", containing("multipart/form-data;"))
                 .withRequestBody(ipaFormData())
                 .withRequestBody(mandatoryFormData(0))

--- a/src/test/java/hockeyapp/FreestyleTest.java
+++ b/src/test/java/hockeyapp/FreestyleTest.java
@@ -197,7 +197,7 @@ public class FreestyleTest extends ProjectTest {
 
         // Then
         assertBuildSuccessful(build);
-        mockHockeyAppServer.verify(1, putRequestedFor(urlEqualTo(HOCKEY_APP_VERSION_UPLOAD_URL))
+        mockHockeyAppServer.verify(1, putRequestedFor(urlEqualTo(HOCKEY_APP_VERSION_UPLOAD_BASE_URL))
                 .withHeader("Content-Type", containing("multipart/form-data;"))
                 .withRequestBody(ipaFormData())
                 .withRequestBody(mandatoryFormData(0))

--- a/src/test/java/hockeyapp/ProjectTest.java
+++ b/src/test/java/hockeyapp/ProjectTest.java
@@ -25,7 +25,7 @@ public abstract class ProjectTest {
     static final String IPA_CONTENTS = "Lorem Ipsum";
 
     static final String HOCKEY_APP_UPLOAD_URL = "/api/2/apps/upload";
-    static final String HOCKEY_APP_VERSION_UPLOAD_URL = "/api/2/apps/" + APP_ID + "/app_versions/1";
+    static final String HOCKEY_APP_VERSION_UPLOAD_BASE_URL = "/api/2/apps/" + APP_ID + "/app_versions/1";
     static final String HOCKEY_APP_DELETE_URL = "/api/2/apps/" + APP_ID + "/app_versions/delete";
 
     @Rule
@@ -61,7 +61,7 @@ public abstract class ProjectTest {
                                 "  \"owner_token\": \"bar-baz\",\n" +
                                 "  \"retention_days\": \"90\"\n" +
                                 "}")));
-        mockHockeyAppServer.stubFor(put(urlEqualTo(HOCKEY_APP_VERSION_UPLOAD_URL))
+        mockHockeyAppServer.stubFor(put(urlEqualTo(HOCKEY_APP_VERSION_UPLOAD_BASE_URL))
                 .willReturn(aResponse()
                         .withHeader("Content-Type", "application/json")
                         .withStatus(201)

--- a/src/test/java/hockeyapp/ProjectTest.java
+++ b/src/test/java/hockeyapp/ProjectTest.java
@@ -25,7 +25,8 @@ public abstract class ProjectTest {
     static final String IPA_CONTENTS = "Lorem Ipsum";
 
     static final String HOCKEY_APP_UPLOAD_URL = "/api/2/apps/upload";
-    static final String HOCKEY_APP_VERSION_UPLOAD_BASE_URL = "/api/2/apps/" + APP_ID + "/app_versions/1";
+    static final String HOCKEY_VERSION_UPLOAD_EXISTING_BASE_URL = "/api/2/apps/" + APP_ID + "/app_versions/";
+    static final String HOCKEY_VERSION_UPLOAD_NEW_URL = "/api/2/apps/" + APP_ID + "/app_versions/upload";
     static final String HOCKEY_APP_DELETE_URL = "/api/2/apps/" + APP_ID + "/app_versions/delete";
 
     @Rule
@@ -35,6 +36,8 @@ public abstract class ProjectTest {
 
     @Before
     public void before() throws Exception {
+        // TODO: Template these responses for more flexibility.
+        // Stub upload app
         mockHockeyAppServer.stubFor(post(urlEqualTo(HOCKEY_APP_UPLOAD_URL))
                 .willReturn(aResponse()
                         .withHeader("Content-Type", "application/json")
@@ -61,7 +64,9 @@ public abstract class ProjectTest {
                                 "  \"owner_token\": \"bar-baz\",\n" +
                                 "  \"retention_days\": \"90\"\n" +
                                 "}")));
-        mockHockeyAppServer.stubFor(put(urlEqualTo(HOCKEY_APP_VERSION_UPLOAD_BASE_URL))
+
+        // Stub upload new version
+        mockHockeyAppServer.stubFor(put(urlPathMatching(HOCKEY_VERSION_UPLOAD_EXISTING_BASE_URL+ "[0-9]+"))  // TODO: Grab version from request param
                 .willReturn(aResponse()
                         .withHeader("Content-Type", "application/json")
                         .withStatus(201)
@@ -87,6 +92,36 @@ public abstract class ProjectTest {
                                 "  \"owner_token\": \"bar-baz\",\n" +
                                 "  \"retention_days\": \"90\"\n" +
                                 "}")));
+
+        // Stub upload existing version
+        mockHockeyAppServer.stubFor(post(urlEqualTo(HOCKEY_VERSION_UPLOAD_NEW_URL))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withStatus(201)
+                        .withBody("{\n" +
+                                "  \"title\": \"Android\",\n" +
+                                "  \"bundle_identifier\": \"net.hockeyapp.jenkins.android\",\n" +
+                                "  \"public_identifier\": \"" + APP_ID + "\",\n" +
+                                "  \"platform\": \"Android\",\n" +
+                                "  \"release_type\": 0,\n" +
+                                "  \"custom_release_type\": null,\n" +
+                                "  \"created_at\": \"2018-06-16T21:16:48Z\",\n" +
+                                "  \"updated_at\": \"2018-06-16T21:16:51Z\",\n" +
+                                "  \"featured\": false,\n" +
+                                "  \"role\": 0,\n" +
+                                "  \"id\": 788014,\n" +
+                                "  \"config_url\": \"https://rink.hockeyapp.net/manage/apps/bar/app_versions/1\",\n" +
+                                "  \"public_url\": \"https://rink.hockeyapp.net/apps/foo\",\n" +
+                                "  \"minimum_os_version\": \"5.0\",\n" +
+                                "  \"device_family\": null,\n" +
+                                "  \"status\": 2,\n" +
+                                "  \"visibility\": \"private\",\n" +
+                                "  \"owner\": \"Foo Bar Inc\",\n" +
+                                "  \"owner_token\": \"bar-baz\",\n" +
+                                "  \"retention_days\": \"90\"\n" +
+                                "}")));
+
+        // Stub delete app
         mockHockeyAppServer.stubFor(post(urlEqualTo(HOCKEY_APP_DELETE_URL))
                 .willReturn(aResponse()
                         .withStatus(204)));


### PR DESCRIPTION
Carried over from regression in #52. Attempting to make the `versionCreation` field optional by making better use of `@DataBoundSetter` functionality.