### PR TITLE
Add support for Credentials plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,16 @@
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>credentials</artifactId>
+            <version>2.1.18</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>plain-credentials</artifactId>
+            <version>1.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
             <version>1.17</version>
         </dependency>

--- a/src/main/java/hockeyapp/HockeyappApplication.java
+++ b/src/main/java/hockeyapp/HockeyappApplication.java
@@ -32,7 +32,11 @@ public class HockeyappApplication implements Describable<HockeyappApplication> {
     @Deprecated
     public long schemaVersion; // TODO: Fix Findbugs gracefully.
 
-    public String apiToken;
+    /**
+     * @deprecated Use {@link #credentialId} instead. This field only exists for upgrade purposes.
+     */
+    @Deprecated
+    public transient String apiToken;
 
     @SuppressFBWarnings(value = {"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"}, justification = "Breaks binary compatibility if removed.")
     @Deprecated
@@ -48,15 +52,17 @@ public class HockeyappApplication implements Describable<HockeyappApplication> {
     public OldVersionHolder oldVersionHolder;
     public RadioButtonSupport releaseNotesMethod;
     public RadioButtonSupport uploadMethod;
+    private String credentialId;
 
     @DataBoundConstructor
-    public HockeyappApplication(String apiToken, String appId, boolean notifyTeam,
+    public HockeyappApplication(String apiToken, String credentialId, String appId, boolean notifyTeam,
                                 String filePath, String dsymPath, String libsPath,
                                 String tags, String teams, boolean mandatory,
                                 boolean downloadAllowed, OldVersionHolder oldVersionHolder,
                                 RadioButtonSupport releaseNotesMethod, RadioButtonSupport uploadMethod) {
         this.schemaVersion = SCHEMA_VERSION_NUMBER;
         this.apiToken = Util.fixEmptyAndTrim(apiToken);
+        this.credentialId = credentialId;
         this.appId = Util.fixEmptyAndTrim(appId);
         this.notifyTeam = notifyTeam;
         this.filePath = Util.fixEmptyAndTrim(filePath);
@@ -96,6 +102,14 @@ public class HockeyappApplication implements Describable<HockeyappApplication> {
     @Override
     public Descriptor<HockeyappApplication> getDescriptor() {
         return new DescriptorImpl();
+    }
+
+    public String getCredentialId() {
+        return credentialId;
+    }
+
+    public void setCredentialId(String credentialId) {
+        this.credentialId = credentialId;
     }
 
     public static class OldVersionHolder {

--- a/src/main/java/hockeyapp/HockeyappApplication.java
+++ b/src/main/java/hockeyapp/HockeyappApplication.java
@@ -4,9 +4,12 @@ import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.Util;
+import hudson.model.AbstractProject;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
+import hudson.model.Item;
 import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
 import net.hockeyapp.jenkins.RadioButtonSupport;
 import net.hockeyapp.jenkins.RadioButtonSupportDescriptor;
@@ -16,6 +19,8 @@ import net.hockeyapp.jenkins.releaseNotes.ManualReleaseNotes;
 import net.hockeyapp.jenkins.releaseNotes.NoReleaseNotes;
 import net.hockeyapp.jenkins.uploadMethod.AppCreation;
 import net.hockeyapp.jenkins.uploadMethod.VersionCreation;
+import net.hockeyapp.jenkins.utils.CredentialUtils;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
@@ -191,7 +196,6 @@ public class HockeyappApplication implements Describable<HockeyappApplication> {
             return uploadMethods;
         }
 
-
         @SuppressWarnings("unused")
         public FormValidation doCheckApiToken(@QueryParameter String value) {
             if (value.isEmpty()) {
@@ -212,6 +216,16 @@ public class HockeyappApplication implements Describable<HockeyappApplication> {
             } else {
                 return FormValidation.ok();
             }
+        }
+
+        @SuppressWarnings("unused")
+        public ListBoxModel doFillCredentialIdItems(@AncestorInPath Item item, @QueryParameter String credentialId) {
+            // TODO: See what this does with more than one publisher in the job
+            final HockeyappRecorder describable = ((AbstractProject<?, ?>) item).getPublishersList().get(HockeyappRecorder.class);
+            final String baseUrl = describable.getBaseUrl();
+
+            // Permission checks are implemented in CredentialUtils
+            return CredentialUtils.getInstance().getAvailableCredentials(item, credentialId, baseUrl);
         }
 
         @SuppressWarnings("unused")

--- a/src/main/java/hockeyapp/HockeyappApplication.java
+++ b/src/main/java/hockeyapp/HockeyappApplication.java
@@ -4,7 +4,6 @@ import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.Util;
-import hudson.model.AbstractProject;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
 import hudson.model.Item;
@@ -222,12 +221,12 @@ public class HockeyappApplication implements Describable<HockeyappApplication> {
 
         @SuppressWarnings("unused")
         public ListBoxModel doFillCredentialIdItems(@AncestorInPath Item item, @QueryParameter String credentialId) {
-            // TODO: See what this does with more than one publisher in the job
-            final HockeyappRecorder describable = ((AbstractProject<?, ?>) item).getPublishersList().get(HockeyappRecorder.class);
-            final String baseUrl = describable.getBaseUrl();
+            final Jenkins jenkins = Jenkins.getInstance();
+            final HockeyappRecorder.DescriptorImpl hockeyappRecorderDescriptor = jenkins.getDescriptorByType(HockeyappRecorder.DescriptorImpl.class);
+            final String defaultBaseUrl = hockeyappRecorderDescriptor.getDefaultBaseUrl();
 
             // Permission checks are implemented in CredentialUtils
-            return CredentialUtils.getInstance().getAvailableCredentials(item, credentialId, baseUrl);
+            return CredentialUtils.getInstance().getAvailableCredentials(item, credentialId, defaultBaseUrl);
         }
 
         @SuppressWarnings("unused")

--- a/src/main/java/hockeyapp/HockeyappApplication.java
+++ b/src/main/java/hockeyapp/HockeyappApplication.java
@@ -241,6 +241,4 @@ public class HockeyappApplication implements Describable<HockeyappApplication> {
             }
         }
     }
-
-
 }

--- a/src/main/java/hockeyapp/HockeyappApplication.java
+++ b/src/main/java/hockeyapp/HockeyappApplication.java
@@ -17,6 +17,7 @@ import net.hockeyapp.jenkins.releaseNotes.NoReleaseNotes;
 import net.hockeyapp.jenkins.uploadMethod.AppCreation;
 import net.hockeyapp.jenkins.uploadMethod.VersionCreation;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.export.ExportedBean;
 
@@ -33,7 +34,7 @@ public class HockeyappApplication implements Describable<HockeyappApplication> {
     public long schemaVersion; // TODO: Fix Findbugs gracefully.
 
     /**
-     * @deprecated Use {@link #credentialId} instead. This field only exists for upgrade purposes.
+     * @deprecated Use {@link HockeyappApplication#getCredentialId()}} instead. This field only exists for upgrade purposes.
      */
     @Deprecated
     public transient String apiToken;
@@ -52,18 +53,38 @@ public class HockeyappApplication implements Describable<HockeyappApplication> {
     public OldVersionHolder oldVersionHolder;
     public RadioButtonSupport releaseNotesMethod;
     public RadioButtonSupport uploadMethod;
+
     private String credentialId;
 
-    @DataBoundConstructor
-    public HockeyappApplication(String apiToken, String credentialId, String appId, boolean notifyTeam,
+    @Deprecated
+    public HockeyappApplication(String apiToken, String appId, boolean notifyTeam,
                                 String filePath, String dsymPath, String libsPath,
                                 String tags, String teams, boolean mandatory,
                                 boolean downloadAllowed, OldVersionHolder oldVersionHolder,
                                 RadioButtonSupport releaseNotesMethod, RadioButtonSupport uploadMethod) {
         this.schemaVersion = SCHEMA_VERSION_NUMBER;
         this.apiToken = Util.fixEmptyAndTrim(apiToken);
-        this.credentialId = credentialId;
         this.appId = Util.fixEmptyAndTrim(appId);
+        this.notifyTeam = notifyTeam;
+        this.filePath = Util.fixEmptyAndTrim(filePath);
+        this.dsymPath = Util.fixEmptyAndTrim(dsymPath);
+        this.libsPath = Util.fixEmptyAndTrim(libsPath);
+        this.tags = Util.fixEmptyAndTrim(tags);
+        this.downloadAllowed = downloadAllowed;
+        this.oldVersionHolder = oldVersionHolder;
+        this.releaseNotesMethod = releaseNotesMethod;
+        this.uploadMethod = uploadMethod;
+        this.teams = Util.fixEmptyAndTrim(teams);
+        this.mandatory = mandatory;
+    }
+
+    @DataBoundConstructor
+    public HockeyappApplication(String credentialId, boolean notifyTeam,
+                                String filePath, String dsymPath, String libsPath,
+                                String tags, String teams, boolean mandatory,
+                                boolean downloadAllowed, OldVersionHolder oldVersionHolder,
+                                RadioButtonSupport releaseNotesMethod, RadioButtonSupport uploadMethod) {
+        this.credentialId = credentialId;
         this.notifyTeam = notifyTeam;
         this.filePath = Util.fixEmptyAndTrim(filePath);
         this.dsymPath = Util.fixEmptyAndTrim(dsymPath);
@@ -87,6 +108,15 @@ public class HockeyappApplication implements Describable<HockeyappApplication> {
         return uploadMethod;
     }
 
+    public String getCredentialId() {
+        return credentialId;
+    }
+
+    @DataBoundSetter
+    public void setCredentialId(String credentialId) {
+        this.credentialId = credentialId;
+    }
+
     public String getNumberOldVersions() {
         return oldVersionHolder == null ? null : oldVersionHolder.numberOldVersions;
     }
@@ -102,14 +132,6 @@ public class HockeyappApplication implements Describable<HockeyappApplication> {
     @Override
     public Descriptor<HockeyappApplication> getDescriptor() {
         return new DescriptorImpl();
-    }
-
-    public String getCredentialId() {
-        return credentialId;
-    }
-
-    public void setCredentialId(String credentialId) {
-        this.credentialId = credentialId;
     }
 
     public static class OldVersionHolder {

--- a/src/main/java/hockeyapp/HockeyappApplication.java
+++ b/src/main/java/hockeyapp/HockeyappApplication.java
@@ -26,6 +26,7 @@ import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.export.ExportedBean;
 
+import javax.annotation.CheckForNull;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -113,6 +114,7 @@ public class HockeyappApplication implements Describable<HockeyappApplication> {
         return uploadMethod;
     }
 
+    @CheckForNull
     public String getCredentialId() {
         return credentialId;
     }

--- a/src/main/java/hockeyapp/HockeyappRecorder.java
+++ b/src/main/java/hockeyapp/HockeyappRecorder.java
@@ -747,10 +747,7 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
 
     @Symbol("hockeyApp")
     @Extension
-    // This indicates to Jenkins that this is an implementation of an extension
-    // point.
-    public static final class DescriptorImpl extends
-            BuildStepDescriptor<Publisher> {
+    public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {
         private String defaultToken;
         private boolean globalDebugMode = false;
         private String timeout;

--- a/src/main/java/hockeyapp/HockeyappRecorder.java
+++ b/src/main/java/hockeyapp/HockeyappRecorder.java
@@ -753,7 +753,7 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
     @Symbol("hockeyApp")
     @Extension
     public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {
-        public static final String DEFAULT_HOCKEY_URL = "https://rink.hockeyapp.net";
+        static final String DEFAULT_HOCKEY_URL = "https://rink.hockeyapp.net";
 
         private String defaultToken;
         private boolean globalDebugMode = false;

--- a/src/main/java/hockeyapp/HockeyappRecorder.java
+++ b/src/main/java/hockeyapp/HockeyappRecorder.java
@@ -24,6 +24,7 @@ import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Publisher;
 import hudson.tasks.Recorder;
 import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
 import hudson.util.RunList;
 import jenkins.model.Jenkins;
 import jenkins.tasks.SimpleBuildStep;
@@ -66,6 +67,7 @@ import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
@@ -190,8 +192,9 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
 
     // Not a getter since build has to know proper value
     public String fetchApiToken(HockeyappApplication application) {
+        // TODO: Get from credentials plugin here?
         if (application.apiToken == null) {
-            return getDescriptor().getDefaultToken();
+            return getDescriptor().getDefaultToken(); // TODO: Don't need this if using credentials plugin as it is all global anyway?
         } else {
             return application.apiToken;
         }
@@ -862,6 +865,16 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
         @Override
         public String getDisplayName() {
             return Messages.UPLOAD_TO_HOCKEYAPP();
+        }
+
+        @SuppressWarnings("unused")
+        public ListBoxModel doFillCredentialIdItems(@AncestorInPath Item item, @QueryParameter String credentialId) {
+            final Jenkins jenkins = Jenkins.getInstance();
+            final HockeyappRecorder.DescriptorImpl hockeyappRecorderDescriptor = jenkins.getDescriptorByType(HockeyappRecorder.DescriptorImpl.class);
+            final String defaultBaseUrl = hockeyappRecorderDescriptor.getDefaultBaseUrl();
+
+            // Permission checks are implemented in CredentialUtils
+            return CredentialUtils.getInstance().getAvailableCredentials(item, credentialId, defaultBaseUrl);
         }
 
         @SuppressWarnings("unused")

--- a/src/main/java/hockeyapp/HockeyappRecorder.java
+++ b/src/main/java/hockeyapp/HockeyappRecorder.java
@@ -823,11 +823,11 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
         }
 
         @Override
-        public boolean configure(StaplerRequest req, JSONObject json) {
-            // XXX is this now the right style?
-            req.bindJSON(this, json);
+        public boolean configure(StaplerRequest request, JSONObject formData) throws FormException {
+            request.bindJSON(this, formData);
+
             save();
-            return true;
+            return super.configure(request, formData);
         }
 
         /**

--- a/src/main/java/hockeyapp/HockeyappRecorder.java
+++ b/src/main/java/hockeyapp/HockeyappRecorder.java
@@ -98,7 +98,12 @@ import java.util.regex.Pattern;
 public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
 
     public static final long SCHEMA_VERSION_NUMBER = 2L;
-    public static final String DEFAULT_HOCKEY_URL = "https://rink.hockeyapp.net";
+
+    /**
+     * @deprecated Prefer {@link DescriptorImpl#DEFAULT_HOCKEY_URL}} instead.
+     */
+    @Deprecated
+    public static final String DEFAULT_HOCKEY_URL = DescriptorImpl.DEFAULT_HOCKEY_URL;
     public static final int DEFAULT_TIMEOUT = 60000;
     private static final String UTF8 = "UTF-8";
     private static final Charset DEFAULT_CHARACTER_SET = StandardCharsets.UTF_8;
@@ -146,7 +151,7 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
 
     @Nonnull
     public String getBaseUrl() {
-        return baseUrl == null ? DEFAULT_HOCKEY_URL : baseUrl;
+        return baseUrl == null ? DescriptorImpl.DEFAULT_HOCKEY_URL : baseUrl;
     }
 
     @DataBoundSetter
@@ -748,6 +753,8 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
     @Symbol("hockeyApp")
     @Extension
     public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {
+        public static final String DEFAULT_HOCKEY_URL = "https://rink.hockeyapp.net";
+
         private String defaultToken;
         private boolean globalDebugMode = false;
         private String timeout;

--- a/src/main/java/hockeyapp/HockeyappRecorder.java
+++ b/src/main/java/hockeyapp/HockeyappRecorder.java
@@ -154,7 +154,7 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
 
     @Nonnull
     public String getBaseUrl() {
-        return baseUrl == null ? DescriptorImpl.DEFAULT_BASE_URL : baseUrl;
+        return baseUrl == null ? getDescriptor().getDefaultBaseUrl() : baseUrl;
     }
 
     @DataBoundSetter

--- a/src/main/java/hockeyapp/HockeyappRecorder.java
+++ b/src/main/java/hockeyapp/HockeyappRecorder.java
@@ -861,13 +861,13 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
         }
 
         @SuppressWarnings("unused")
-        public ListBoxModel doFillCredentialIdItems(@AncestorInPath Item item, @QueryParameter String credentialId) {
+        public ListBoxModel doFillGlobalCredentialIdItems(@AncestorInPath Item item, @QueryParameter String globalCredentialId) {
             final Jenkins jenkins = Jenkins.getInstance();
             final HockeyappRecorder.DescriptorImpl hockeyappRecorderDescriptor = jenkins.getDescriptorByType(HockeyappRecorder.DescriptorImpl.class);
             final String defaultBaseUrl = hockeyappRecorderDescriptor.getDefaultBaseUrl();
 
             // Permission checks are implemented in CredentialUtils
-            return CredentialUtils.getInstance().getAvailableCredentials(item, credentialId, defaultBaseUrl);
+            return CredentialUtils.getInstance().getAvailableCredentials(item, globalCredentialId, defaultBaseUrl);
         }
 
         @SuppressWarnings("unused")

--- a/src/main/java/hockeyapp/HockeyappRecorder.java
+++ b/src/main/java/hockeyapp/HockeyappRecorder.java
@@ -779,7 +779,7 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
         @SuppressWarnings("unused") // Used by Jenkins
         public void setDefaultToken(String defaultToken) {
             this.defaultToken = Util.fixEmptyAndTrim(defaultToken);
-            save();
+            save(); // TODO: Remove this. Operation done on configure.
         }
 
         public boolean getGlobalDebugMode() {
@@ -790,7 +790,7 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
         @SuppressWarnings("unused") // Used by Jenkins
         public void setGlobalDebugMode(boolean globalDebugMode) {
             this.globalDebugMode = globalDebugMode;
-            save();
+            save(); // TODO: Remove this. Operation done on configure.
         }
 
         @SuppressWarnings("unused")
@@ -801,7 +801,7 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
         @SuppressWarnings("unused")
         public void setTimeout(String timeout) {
             this.timeout = Util.fixEmptyAndTrim(timeout);
-            save();
+            save(); // TODO: Remove this. Operation done on configure.
         }
 
         public int getTimeoutInt() {

--- a/src/main/java/hockeyapp/HockeyappRecorder.java
+++ b/src/main/java/hockeyapp/HockeyappRecorder.java
@@ -355,7 +355,7 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
                     entity.addPart("ipa", fileBody);
 
                     if (application.dsymPath != null && !vars.expand(application.dsymPath).isEmpty()) {
-                        FilePath remoteDsymFiles[] = remoteWorkspace.list(vars.expand(application.dsymPath));
+                        FilePath[] remoteDsymFiles = remoteWorkspace.list(vars.expand(application.dsymPath));
                         // Take the first one that matches the pattern
                         if (remoteDsymFiles.length == 0) {
                             logger.println("No dSYM found to upload in: " + vars.expand(application.dsymPath));
@@ -368,7 +368,7 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
                     }
 
                     if (application.libsPath != null && !vars.expand(application.libsPath).isEmpty()) {
-                        FilePath remoteLibsFiles[] = remoteWorkspace.list(vars.expand(application.libsPath));
+                        FilePath[] remoteLibsFiles = remoteWorkspace.list(vars.expand(application.libsPath));
                         // Take the first one that matches the pattern
                         if (remoteLibsFiles.length == 0) {
                             logger.println("No LIBS found to upload in: " + vars.expand(application.libsPath));

--- a/src/main/java/hockeyapp/HockeyappRecorder.java
+++ b/src/main/java/hockeyapp/HockeyappRecorder.java
@@ -159,7 +159,8 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
 
     @DataBoundSetter
     public void setBaseUrl(@Nonnull String baseUrl) {
-        this.baseUrl = baseUrl.isEmpty() ? null : baseUrl;
+        final boolean isSameAsDefault = baseUrl.equals(getDescriptor().getDefaultBaseUrl());
+        this.baseUrl = baseUrl.isEmpty() || isSameAsDefault ? null : baseUrl;
     }
 
     @Deprecated

--- a/src/main/java/hockeyapp/HockeyappRecorder.java
+++ b/src/main/java/hockeyapp/HockeyappRecorder.java
@@ -767,6 +767,10 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
             load();
         }
 
+        public String getDefaultHockeyUrl() {
+            return DEFAULT_HOCKEY_URL;
+        }
+
         public String getDefaultToken() {
             return defaultToken;
         }

--- a/src/main/java/hockeyapp/HockeyappRecorder.java
+++ b/src/main/java/hockeyapp/HockeyappRecorder.java
@@ -102,10 +102,10 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
     public static final long SCHEMA_VERSION_NUMBER = 2L;
 
     /**
-     * @deprecated Prefer {@link DescriptorImpl#DEFAULT_HOCKEY_URL}} instead.
+     * @deprecated Prefer {@link DescriptorImpl#DEFAULT_BASE_URL}} instead.
      */
     @Deprecated
-    public static final String DEFAULT_HOCKEY_URL = DescriptorImpl.DEFAULT_HOCKEY_URL;
+    public static final String DEFAULT_HOCKEY_URL = DescriptorImpl.DEFAULT_BASE_URL;
     public static final int DEFAULT_TIMEOUT = 60000;
     private static final Logger LOGGER = Logger.getLogger(HockeyappRecorder.class.getName());
     private static final String UTF8 = "UTF-8";
@@ -154,7 +154,7 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
 
     @Nonnull
     public String getBaseUrl() {
-        return baseUrl == null ? DescriptorImpl.DEFAULT_HOCKEY_URL : baseUrl;
+        return baseUrl == null ? DescriptorImpl.DEFAULT_BASE_URL : baseUrl;
     }
 
     @DataBoundSetter
@@ -756,7 +756,7 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
     @Symbol("hockeyApp")
     @Extension
     public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {
-        static final String DEFAULT_HOCKEY_URL = "https://rink.hockeyapp.net";
+        static final String DEFAULT_BASE_URL = "https://rink.hockeyapp.net";
 
         private String defaultToken; // TODO: Change the naming to global and deprecate the getter / setter
         private boolean globalDebugMode = false;
@@ -767,8 +767,8 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
             load();
         }
 
-        public String getDefaultHockeyUrl() {
-            return DEFAULT_HOCKEY_URL;
+        public String getDefaultBaseUrl() {
+            return DEFAULT_BASE_URL;
         }
 
         public String getDefaultToken() {

--- a/src/main/java/hockeyapp/HockeyappRecorder.java
+++ b/src/main/java/hockeyapp/HockeyappRecorder.java
@@ -93,6 +93,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Scanner;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
 public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
@@ -105,6 +107,7 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
     @Deprecated
     public static final String DEFAULT_HOCKEY_URL = DescriptorImpl.DEFAULT_HOCKEY_URL;
     public static final int DEFAULT_TIMEOUT = 60000;
+    private static final Logger LOGGER = Logger.getLogger(HockeyappRecorder.class.getName());
     private static final String UTF8 = "UTF-8";
     private static final Charset DEFAULT_CHARACTER_SET = StandardCharsets.UTF_8;
     private static final ContentType DEFAULT_CONTENT_TYPE = ContentType.create("text/plain", Consts.UTF_8);

--- a/src/main/java/hockeyapp/HockeyappRecorder.java
+++ b/src/main/java/hockeyapp/HockeyappRecorder.java
@@ -755,9 +755,9 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
     public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {
         static final String DEFAULT_HOCKEY_URL = "https://rink.hockeyapp.net";
 
-        private String defaultToken;
+        private String defaultToken; // TODO: Change the naming to global and deprecate the getter / setter
         private boolean globalDebugMode = false;
-        private String timeout;
+        private String timeout; // TODO: Change the naming to global and deprecate the getter / setter
 
         public DescriptorImpl() {
             super(HockeyappRecorder.class);

--- a/src/main/java/hockeyapp/HockeyappRecorder.java
+++ b/src/main/java/hockeyapp/HockeyappRecorder.java
@@ -84,7 +84,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
-import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.Charset;
@@ -334,7 +333,8 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
 
                     HttpInfo info = getHttpInfo(logger, vars, application);
                     String path = info.getPath();
-                    URL host = createHostUrl(vars);
+                    final String baseUrl = vars.expand(getBaseUrl());
+                    final URL host = new URL(baseUrl);
                     URL url = new URL(host, path);
 
                     HttpClient httpclient = createPreconfiguredHttpClient(url, logger);
@@ -603,16 +603,6 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
             }
         }
         return null;
-    }
-
-    private URL createHostUrl(EnvVars vars) throws MalformedURLException {
-        URL host;
-        if (baseUrl != null && !baseUrl.isEmpty()) {
-            host = new URL(vars.expand(baseUrl));
-        } else {
-            host = new URL(DEFAULT_HOCKEY_URL);
-        }
-        return host;
     }
 
     private void printUploadSpeed(long duration, float fileSize, PrintStream logger) {

--- a/src/main/java/hockeyapp/HockeyappRecorder.java
+++ b/src/main/java/hockeyapp/HockeyappRecorder.java
@@ -754,13 +754,13 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
         static final String DEFAULT_BASE_URL = "https://rink.hockeyapp.net";
 
         /**
-         * @deprecated Use {@link #credentialId} instead. This field only exists for upgrade purposes.
+         * @deprecated Use {@link #globalCredentialId} instead. This field only exists for upgrade purposes.
          */
         @Deprecated
-        private transient String defaultToken; // TODO: Change the naming to global and deprecate the getter / setter
+        private transient String defaultToken;
         private boolean globalDebugMode = false;
         private String timeout; // TODO: Change the naming to global and deprecate the getter / setter
-        private String credentialId;
+        private String globalCredentialId;
 
         public DescriptorImpl() {
             super(HockeyappRecorder.class);
@@ -792,12 +792,13 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
             save(); // TODO: Remove this. Operation done on configure.
         }
 
-        public String getCredentialId() {
-            return credentialId;
+        @CheckForNull
+        public String getGlobalCredentialId() {
+            return globalCredentialId;
         }
 
-        public void setCredentialId(String credentialId) {
-            this.credentialId = credentialId;
+        public void setGlobalCredentialId(String globalCredentialId) {
+            this.globalCredentialId = globalCredentialId;
         }
 
         public boolean getGlobalDebugMode() {

--- a/src/main/java/net/hockeyapp/jenkins/migrators/TokenMigrator.java
+++ b/src/main/java/net/hockeyapp/jenkins/migrators/TokenMigrator.java
@@ -1,0 +1,55 @@
+package net.hockeyapp.jenkins.migrators;
+
+import hockeyapp.HockeyappRecorder;
+import hudson.BulkChange;
+import hudson.Extension;
+import hudson.Plugin;
+import hudson.model.AbstractProject;
+import hudson.model.listeners.ItemListener;
+import jenkins.model.Jenkins;
+import net.hockeyapp.jenkins.utils.CredentialUtils;
+
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@Extension
+public class TokenMigrator extends ItemListener {
+
+    private static final Logger LOGGER = Logger.getLogger(TokenMigrator.class.getName());
+
+    @Override
+    public void onLoaded() {
+        super.onLoaded();
+
+        final Jenkins jenkins = Jenkins.getInstance();
+        final HockeyappRecorder.DescriptorImpl hockeyappRecorderDescriptor = jenkins.getDescriptorByType(HockeyappRecorder.DescriptorImpl.class);
+        final Plugin hockeyapp = jenkins.getPlugin("hockeyapp"); // Gets the currently installed plugin by name
+
+        if (hockeyapp == null) {
+            return; // No point trying to migrate if we don't have something to migrate to
+        }
+
+        for (AbstractProject<?, ?> item : jenkins.getAllItems(AbstractProject.class)) {
+            final HockeyappRecorder hockeyappRecorder = item.getPublishersList().get(HockeyappRecorder.class);
+
+            BulkChange bc = new BulkChange(item);
+            if (hockeyappRecorder != null) {
+                final CredentialUtils credentialUtils = CredentialUtils.getInstance();
+                try {
+                    LOGGER.log(Level.FINER, "Attempting to migrate credentials for job: {0}", item.getFullDisplayName());
+                    credentialUtils.migrateJobCredential(item, hockeyappRecorder);
+                    LOGGER.log(Level.FINER, "Successfully migrated credential for job: {0}", item.getFullDisplayName());
+                    item.save();
+                    bc.commit();
+                } catch (IOException e) {
+                    LOGGER.log(Level.SEVERE, "Unable to save configuration for job: " + item.getFullName(), e);
+                } finally {
+                    bc.abort();
+                }
+            }
+        }
+
+        hockeyappRecorderDescriptor.save();
+    }
+}

--- a/src/main/java/net/hockeyapp/jenkins/utils/CredentialUtils.java
+++ b/src/main/java/net/hockeyapp/jenkins/utils/CredentialUtils.java
@@ -3,6 +3,7 @@ package net.hockeyapp.jenkins.utils;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.CredentialsStore;
+import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.domains.Domain;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import com.cloudbees.plugins.credentials.domains.DomainSpecification;
@@ -13,12 +14,17 @@ import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
 import hockeyapp.HockeyappApplication;
 import hockeyapp.HockeyappRecorder;
 import hudson.model.Item;
+import hudson.model.Queue;
+import hudson.model.queue.Tasks;
 import hudson.security.ACL;
+import hudson.util.ListBoxModel;
 import hudson.util.Secret;
 import jenkins.model.Jenkins;
+import org.acegisecurity.Authentication;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
 
+import javax.annotation.CheckForNull;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -46,6 +52,47 @@ public class CredentialUtils {
             }
         }
         return instance;
+    }
+
+    /**
+     * Retrieves the UI model object containing all acceptable credentials. This method can operate in two modes.
+     *
+     * <ul>
+     * <li>When item is null: in this case the credentials will be looked up globally. In this case the assumption
+     * is that we are displaying the credential dropdown on the global config page.</li>
+     * <li>When item is not null: in this case the credentials will be looked up within the context of the job. In
+     * this case the assumption is that we are displaying the credential dropdown on the job config page.</li>
+     * </ul>
+     *
+     * @param item         The context (job) to use to find the the credentials. May be null. In job config mode, the current
+     *                     value of the credential setting will be extracted from this item.
+     * @param credentialId In global config mode, use this as the currently selected credential.
+     * @param server       The URL to the server to ensure that we find the credentials under the right security
+     *                     domain.
+     * @return The UI model containing all matching credentials, or only the current selection if the user does not have
+     * the right set of permissions.
+     */
+    public ListBoxModel getAvailableCredentials(@CheckForNull final Item item, final String credentialId, final String server) {
+        StandardListBoxModel model = new StandardListBoxModel();
+
+        if (!hasPermissionToConfigureCredentials(item)) {
+            return new StandardListBoxModel().includeCurrentValue(credentialId);
+        }
+
+        Authentication credentialAuthentication = item instanceof Queue.Task ?
+                Tasks.getAuthenticationOf((Queue.Task) item) : ACL.SYSTEM;
+
+        if (item == null) {
+            model.includeAs(credentialAuthentication, Jenkins.getInstance(), StringCredentials.class, requirements(server));
+        } else {
+            model.includeAs(credentialAuthentication, item, StringCredentials.class, requirements(server));
+        }
+
+        if (credentialId != null) {
+            model.includeCurrentValue(credentialId);
+        }
+
+        return model.includeEmptyValue();
     }
 
     /**
@@ -116,7 +163,19 @@ public class CredentialUtils {
         return credential.getId();
     }
 
-    private String generateCredentialId(List<String> existingIds) {
+    private boolean hasPermissionToConfigureCredentials(@CheckForNull final Item item) {
+        if (item == null) {
+            return Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER);
+        }
+
+        final boolean canReadAndUse = item.hasPermission(Item.EXTENDED_READ) && item.hasPermission(CredentialsProvider.USE_ITEM);
+        final boolean canConfigure = item.hasPermission(Item.CONFIGURE);
+
+        return canReadAndUse || canConfigure;
+
+    }
+
+    private String generateCredentialId(final List<String> existingIds) {
         // Users may already have a credential id with this name so try and account for this.
         String candidate = DEFAULT_TOKEN_NAME;
         int i = 2;
@@ -126,7 +185,7 @@ public class CredentialUtils {
         return candidate;
     }
 
-    private List<DomainRequirement> requirements(String baseUrl) {
+    private List<DomainRequirement> requirements(final String baseUrl) {
         return URIRequirementBuilder.create().withHostname(baseUrl).build();
     }
 }

--- a/src/main/java/net/hockeyapp/jenkins/utils/CredentialUtils.java
+++ b/src/main/java/net/hockeyapp/jenkins/utils/CredentialUtils.java
@@ -170,13 +170,15 @@ public class CredentialUtils {
         final BaseStandardCredentials credential = new StringCredentialsImpl(CredentialsScope.GLOBAL, id, description, Secret.fromString(apiToken));
 
         if (store.isDomainsModifiable()) {
+            final String domainName = "HockeyApp";
+            final String domainDescription = "Automatically created domain. Identify usage and apply a more meaningful name and description.";
             final Domain domain = store.getDomainByName(baseUrl);
             if (domain == null) {
                 // If we don't have a domain in the store for our credential, create a domain and the credential at the same time.
                 final List<DomainSpecification> specs = new ArrayList<>();
                 specs.add(new HostnameSpecification(baseUrl, null));
                 specs.add(new SchemeSpecification("https"));
-                final Domain newDomain = new Domain(baseUrl, "HockeyApp", specs);
+                final Domain newDomain = new Domain(domainName, domainDescription, specs);
                 store.addDomain(newDomain, credential);
             } else {
                 // Otherwise we have a domain so add the credential.

--- a/src/main/java/net/hockeyapp/jenkins/utils/CredentialUtils.java
+++ b/src/main/java/net/hockeyapp/jenkins/utils/CredentialUtils.java
@@ -32,7 +32,7 @@ import java.util.List;
 public class CredentialUtils {
 
     private static CredentialUtils instance;
-    private final String DEFAULT_TOKEN_NAME = "HockeyApp-API-Token";
+    private final String DEFAULT_TOKEN_NAME = "hockeyapp-api-token";
 
     private CredentialUtils() {
     }

--- a/src/main/java/net/hockeyapp/jenkins/utils/CredentialUtils.java
+++ b/src/main/java/net/hockeyapp/jenkins/utils/CredentialUtils.java
@@ -1,0 +1,26 @@
+package net.hockeyapp.jenkins.utils;
+
+/**
+ * Utilities to help with credential related tasks, such as credential lookup and migration of insecurely
+ * stored credentials.
+ * <p>
+ * Based on the same class from https://github.com/jenkinsci/hipchat-plugin
+ */
+public class CredentialUtils {
+
+    private static CredentialUtils instance;
+
+    private CredentialUtils() {
+    }
+
+    public static CredentialUtils getInstance() {
+        if (instance == null) {
+            synchronized (CredentialUtils.class) {
+                if (instance == null) {
+                    instance = new CredentialUtils();
+                }
+            }
+        }
+        return instance;
+    }
+}

--- a/src/main/java/net/hockeyapp/jenkins/utils/CredentialUtils.java
+++ b/src/main/java/net/hockeyapp/jenkins/utils/CredentialUtils.java
@@ -15,6 +15,7 @@ import hockeyapp.HockeyappApplication;
 import hockeyapp.HockeyappRecorder;
 import hudson.model.Item;
 import hudson.model.Queue;
+import hudson.model.Run;
 import hudson.model.queue.Tasks;
 import hudson.security.ACL;
 import hudson.util.ListBoxModel;
@@ -25,6 +26,7 @@ import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
 
 import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -52,6 +54,19 @@ public class CredentialUtils {
             }
         }
         return instance;
+    }
+
+    /**
+     * Finds the credential with the given credentialId in the CredentialStore.
+     *
+     * @param run          The Run defining the context within which to find the credential.
+     * @param credentialId The ID of the credential.
+     * @param server       The URL to the server to ensure that we find the credential under the right security domain.
+     * @return The found credential, or null if the credential cannot be found.
+     */
+    @CheckForNull
+    public StringCredentials resolveCredential(@Nonnull final Run<?, ?> run, @CheckForNull final String credentialId, @Nonnull final String server) {
+        return credentialId == null ? null : CredentialsProvider.findCredentialById(credentialId, StringCredentials.class, run, requirements(server));
     }
 
     /**

--- a/src/main/java/net/hockeyapp/jenkins/utils/CredentialUtils.java
+++ b/src/main/java/net/hockeyapp/jenkins/utils/CredentialUtils.java
@@ -96,6 +96,33 @@ public class CredentialUtils {
     }
 
     /**
+     * Migrates the credential stored in global config from the old insecure format to the Credential system.
+     *
+     * @param descriptor The descriptor of this plugin.
+     * @throws IOException If there was an error whilst migrating the credential.
+     */
+    public void migrateGlobalCredential(HockeyappRecorder.DescriptorImpl descriptor) throws IOException {
+        final String defaultToken = descriptor.getDefaultToken();
+        final String defaultHockeyUrl = descriptor.getDefaultBaseUrl();
+
+        if (defaultToken == null) {
+            return; // N point migrating a token that doesn't exist.
+        }
+
+        List<StringCredentials> existingCredentials = CredentialsProvider.lookupCredentials(
+                StringCredentials.class,
+                Jenkins.getInstance(),
+                ACL.SYSTEM,
+                requirements(defaultHockeyUrl)
+        );
+
+        String credentialId = storeCredential(existingCredentials, defaultHockeyUrl, defaultToken);
+
+        descriptor.setDefaultToken(null);
+        descriptor.setCredentialId(credentialId);
+    }
+
+    /**
      * Migrates the credential stored in a job config from the old insecure format to the Credential system.
      *
      * @param item              The job where the plugin is configured.

--- a/src/main/java/net/hockeyapp/jenkins/utils/CredentialUtils.java
+++ b/src/main/java/net/hockeyapp/jenkins/utils/CredentialUtils.java
@@ -84,6 +84,7 @@ public class CredentialUtils {
 
         if (item == null) {
             model.includeAs(credentialAuthentication, Jenkins.getInstance(), StringCredentials.class, requirements(server));
+            model.includeEmptyValue();
         } else {
             model.includeAs(credentialAuthentication, item, StringCredentials.class, requirements(server));
         }
@@ -92,7 +93,7 @@ public class CredentialUtils {
             model.includeCurrentValue(credentialId);
         }
 
-        return model.includeEmptyValue();
+        return model;
     }
 
     /**

--- a/src/main/java/net/hockeyapp/jenkins/utils/CredentialUtils.java
+++ b/src/main/java/net/hockeyapp/jenkins/utils/CredentialUtils.java
@@ -47,12 +47,9 @@ public class CredentialUtils {
 
     public static CredentialUtils getInstance() {
         if (instance == null) {
-            synchronized (CredentialUtils.class) {
-                if (instance == null) {
-                    instance = new CredentialUtils();
-                }
-            }
+            instance = new CredentialUtils();
         }
+
         return instance;
     }
 

--- a/src/main/java/net/hockeyapp/jenkins/utils/CredentialUtils.java
+++ b/src/main/java/net/hockeyapp/jenkins/utils/CredentialUtils.java
@@ -176,7 +176,7 @@ public class CredentialUtils {
                 final List<DomainSpecification> specs = new ArrayList<>();
                 specs.add(new HostnameSpecification(baseUrl, null));
                 specs.add(new SchemeSpecification("https"));
-                final Domain newDomain = new Domain(baseUrl, null, specs);
+                final Domain newDomain = new Domain(baseUrl, "HockeyApp", specs);
                 store.addDomain(newDomain, credential);
             } else {
                 // Otherwise we have a domain so add the credential.

--- a/src/main/java/net/hockeyapp/jenkins/utils/CredentialUtils.java
+++ b/src/main/java/net/hockeyapp/jenkins/utils/CredentialUtils.java
@@ -39,8 +39,8 @@ import java.util.List;
  */
 public class CredentialUtils {
 
+    private final static String DEFAULT_TOKEN_NAME = "hockeyapp-api-token";
     private static CredentialUtils instance;
-    private final String DEFAULT_TOKEN_NAME = "hockeyapp-api-token";
 
     private CredentialUtils() {
     }

--- a/src/main/java/net/hockeyapp/jenkins/utils/CredentialUtils.java
+++ b/src/main/java/net/hockeyapp/jenkins/utils/CredentialUtils.java
@@ -66,7 +66,12 @@ public class CredentialUtils {
         );
 
         for (HockeyappApplication hockeyappApplication : hockeyappRecorder.getApplications()) {
-            final String credentialId = storeCredential(hockeyappRecorder, existingCredentials, hockeyappApplication.apiToken);
+            final String apiToken = hockeyappApplication.apiToken;
+            if (apiToken == null) {
+                continue; // No point migrating a token that doesn't exist.
+            }
+
+            final String credentialId = storeCredential(hockeyappRecorder, existingCredentials, apiToken);
 
             hockeyappApplication.apiToken = null;
             hockeyappApplication.setCredentialId(credentialId);

--- a/src/main/java/net/hockeyapp/jenkins/utils/CredentialUtils.java
+++ b/src/main/java/net/hockeyapp/jenkins/utils/CredentialUtils.java
@@ -92,7 +92,7 @@ public class CredentialUtils {
 
         final CredentialsStore store = CredentialsProvider.lookupStores(Jenkins.getInstance()).iterator().next();
         final String id = generateCredentialId(existingIds);
-        final String description = "Automatically migrated. Identify usage and apply a more meaningful id and description.";
+        final String description = String.format("%s. Automatically migrated. Identify usage and apply a more meaningful id and description.", id);
         final BaseStandardCredentials credential = new StringCredentialsImpl(CredentialsScope.GLOBAL, id, description, Secret.fromString(apiToken));
 
         if (store.isDomainsModifiable()) {

--- a/src/main/java/net/hockeyapp/jenkins/utils/CredentialUtils.java
+++ b/src/main/java/net/hockeyapp/jenkins/utils/CredentialUtils.java
@@ -106,7 +106,7 @@ public class CredentialUtils {
         final String defaultHockeyUrl = descriptor.getDefaultBaseUrl();
 
         if (defaultToken == null) {
-            return; // N point migrating a token that doesn't exist.
+            return; // No point migrating a token that doesn't exist.
         }
 
         List<StringCredentials> existingCredentials = CredentialsProvider.lookupCredentials(

--- a/src/main/java/net/hockeyapp/jenkins/utils/CredentialUtils.java
+++ b/src/main/java/net/hockeyapp/jenkins/utils/CredentialUtils.java
@@ -117,10 +117,10 @@ public class CredentialUtils {
                 requirements(defaultHockeyUrl)
         );
 
-        String credentialId = storeCredential(existingCredentials, defaultHockeyUrl, defaultToken);
+        String globalCrendentialId = storeCredential(existingCredentials, defaultHockeyUrl, defaultToken);
 
         descriptor.setDefaultToken(null);
-        descriptor.setCredentialId(credentialId);
+        descriptor.setGlobalCredentialId(globalCrendentialId);
     }
 
     /**

--- a/src/main/java/net/hockeyapp/jenkins/utils/CredentialUtils.java
+++ b/src/main/java/net/hockeyapp/jenkins/utils/CredentialUtils.java
@@ -112,21 +112,21 @@ public class CredentialUtils {
                 continue; // No point migrating a token that doesn't exist.
             }
 
-            final String credentialId = storeCredential(item, baseUrl, apiToken);
+            final List<StringCredentials> existingCredentials = CredentialsProvider.lookupCredentials(
+                    StringCredentials.class,
+                    item,
+                    ACL.SYSTEM,
+                    requirements(baseUrl)
+            );
+
+            final String credentialId = storeCredential(existingCredentials, baseUrl, apiToken);
 
             hockeyappApplication.apiToken = null;
             hockeyappApplication.setCredentialId(credentialId);
         }
     }
 
-    private String storeCredential(final Item item, final String baseUrl, final String apiToken) throws IOException {
-        final List<StringCredentials> existingCredentials = CredentialsProvider.lookupCredentials(
-                StringCredentials.class,
-                item,
-                ACL.SYSTEM,
-                requirements(baseUrl)
-        );
-
+    private String storeCredential(final List<StringCredentials> existingCredentials, final String baseUrl, final String apiToken) throws IOException {
         final List<String> existingIds = new ArrayList<>();
 
         for (StringCredentials credential : existingCredentials) {

--- a/src/main/java/net/hockeyapp/jenkins/utils/CredentialUtils.java
+++ b/src/main/java/net/hockeyapp/jenkins/utils/CredentialUtils.java
@@ -1,5 +1,28 @@
 package net.hockeyapp.jenkins.utils;
 
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.CredentialsStore;
+import com.cloudbees.plugins.credentials.domains.Domain;
+import com.cloudbees.plugins.credentials.domains.DomainRequirement;
+import com.cloudbees.plugins.credentials.domains.DomainSpecification;
+import com.cloudbees.plugins.credentials.domains.HostnameSpecification;
+import com.cloudbees.plugins.credentials.domains.SchemeSpecification;
+import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
+import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
+import hockeyapp.HockeyappApplication;
+import hockeyapp.HockeyappRecorder;
+import hudson.model.Item;
+import hudson.security.ACL;
+import hudson.util.Secret;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
+import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Utilities to help with credential related tasks, such as credential lookup and migration of insecurely
  * stored credentials.
@@ -9,6 +32,7 @@ package net.hockeyapp.jenkins.utils;
 public class CredentialUtils {
 
     private static CredentialUtils instance;
+    private final String DEFAULT_TOKEN_NAME = "HockeyApp-API-Token";
 
     private CredentialUtils() {
     }
@@ -22,5 +46,80 @@ public class CredentialUtils {
             }
         }
         return instance;
+    }
+
+    /**
+     * Migrates the credential stored in a job config from the old insecure format to the Credential system.
+     *
+     * @param item              The job where the plugin is configured.
+     * @param hockeyappRecorder The plugin instance corresponding to this job.
+     * @throws IOException If there was an error whilst migrating the credential.
+     */
+    @SuppressWarnings("deprecation")
+    public void migrateJobCredential(final Item item, final HockeyappRecorder hockeyappRecorder) throws IOException {
+        final String baseUrl = hockeyappRecorder.getBaseUrl();
+        final List<StringCredentials> existingCredentials = CredentialsProvider.lookupCredentials(
+                StringCredentials.class,
+                item,
+                ACL.SYSTEM,
+                requirements(baseUrl)
+        );
+
+        for (HockeyappApplication hockeyappApplication : hockeyappRecorder.getApplications()) {
+            final String credentialId = storeCredential(hockeyappRecorder, existingCredentials, hockeyappApplication.apiToken);
+
+            hockeyappApplication.apiToken = null;
+            hockeyappApplication.setCredentialId(credentialId);
+        }
+    }
+
+    private String storeCredential(final HockeyappRecorder hockeyappRecorder, final List<StringCredentials> existingCredentials, final String apiToken) throws IOException {
+        final List<String> existingIds = new ArrayList<>();
+        for (StringCredentials credential : existingCredentials) {
+            existingIds.add(credential.getId());
+            if (credential.getId().startsWith(DEFAULT_TOKEN_NAME) && apiToken.equals(Secret.toString(credential.getSecret()))) {
+                // If we have already stored a credential for this api token then return the credential's id.
+                return credential.getId();
+            }
+        }
+
+        final CredentialsStore store = CredentialsProvider.lookupStores(Jenkins.getInstance()).iterator().next();
+        final String id = generateCredentialId(existingIds);
+        final BaseStandardCredentials credential = new StringCredentialsImpl(CredentialsScope.GLOBAL, id, id, Secret.fromString(apiToken));
+
+        if (store.isDomainsModifiable()) {
+            final String baseUrl = hockeyappRecorder.getBaseUrl();
+            final Domain domain = store.getDomainByName(baseUrl);
+            if (domain == null) {
+                // If we don't have a domain in the store for our credential, create a domain and the credential at the same time.
+                final List<DomainSpecification> specs = new ArrayList<>();
+                specs.add(new HostnameSpecification(baseUrl, null));
+                specs.add(new SchemeSpecification("https"));
+                final Domain newDomain = new Domain(baseUrl, null, specs);
+                store.addDomain(newDomain, credential);
+            } else {
+                // Otherwise we have a domain so add the credential.
+                store.addCredentials(domain, credential);
+            }
+        } else {
+            // Otherwise just add it to the global domain and be done with it.
+            store.addCredentials(Domain.global(), credential);
+        }
+
+        return credential.getId();
+    }
+
+    private String generateCredentialId(List<String> existingIds) {
+        // Users may already have a credential id with this name so try and account for this.
+        String candidate = DEFAULT_TOKEN_NAME;
+        int i = 2;
+        while (existingIds.contains(candidate)) {
+            candidate = DEFAULT_TOKEN_NAME + "-" + i++;
+        }
+        return candidate;
+    }
+
+    private List<DomainRequirement> requirements(String baseUrl) {
+        return URIRequirementBuilder.fromUri(baseUrl).build();
     }
 }

--- a/src/main/resources/hockeyapp/HockeyappApplication/config.jelly
+++ b/src/main/resources/hockeyapp/HockeyappApplication/config.jelly
@@ -1,9 +1,10 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler"
-         xmlns:f="/lib/form">
+         xmlns:f="/lib/form"
+         xmlns:c="/lib/credentials">
 
-    <f:entry title="${%API Token}" field="apiToken">
-        <f:textbox checkUrl="'descriptorByName/hockeyapp.HockeyappApplication/checkApiToken?value='+escape(this.value)"/>
+    <f:entry title="${%Credentials}" field="credentialId">
+        <c:select/>
     </f:entry>
     <f:entry title="${%Upload Method}">
         <table width="100%">
@@ -27,7 +28,8 @@
     </f:entry>
 
     <f:entry title="${%App File} (${%.ipa, .app.zip, .apk})" field="filePath">
-        <f:textbox checkUrl="'descriptorByName/hockeyapp.HockeyappApplication/checkFilePath?value='+escape(this.value)"/>
+        <f:textbox
+                checkUrl="'descriptorByName/hockeyapp.HockeyappApplication/checkFilePath?value='+escape(this.value)"/>
     </f:entry>
     <f:entry title="${%Symbols} (${%.dSYM.zip or mapping.txt})" field="dsymPath">
         <f:textbox/>
@@ -98,7 +100,8 @@
     <f:entry>
         <div align="right">
             <input type="button" value="${%Add an application}..." class="repeatable-add show-if-last"/>
-            <input type="button" value="${%Delete}" class="repeatable-delete show-if-not-only" style="margin-left: 1em;"/>
+            <input type="button" value="${%Delete}" class="repeatable-delete show-if-not-only"
+                   style="margin-left: 1em;"/>
         </div>
     </f:entry>
 </j:jelly>

--- a/src/main/resources/hockeyapp/HockeyappApplication/help-credentialsId.html
+++ b/src/main/resources/hockeyapp/HockeyappApplication/help-credentialsId.html
@@ -1,0 +1,11 @@
+<div>
+    Your HockeyApp API Token.<br/>
+    Can be <a href="https://rink.hockeyapp.net/manage/auth_tokens">generated</a> in your HockeyApp account
+    settings.<br/>
+    You need to create a token with full access if you mark your releases as be available for download as soon as
+    they're uploaded.
+</div>
+
+<div>
+    <i>When left undefined and a global API Token is defined, the latter one is used.</i>
+</div>

--- a/src/main/resources/hockeyapp/HockeyappRecorder/global.jelly
+++ b/src/main/resources/hockeyapp/HockeyappRecorder/global.jelly
@@ -1,8 +1,10 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core"
+         xmlns:f="/lib/form"
+         xmlns:c="/lib/credentials">
     <f:section title="${%Default HockeyApp Configuration}">
-        <f:entry title="${%Default API Token}" field="defaultToken">
-            <f:textbox/>
+        <f:entry title="${%Credentials}" field="credentialId">
+            <c:select/>
         </f:entry>
         <f:entry title="${%HTTP Client Timeout}" field="timeout">
             <f:textbox

--- a/src/main/resources/hockeyapp/HockeyappRecorder/global.jelly
+++ b/src/main/resources/hockeyapp/HockeyappRecorder/global.jelly
@@ -2,8 +2,8 @@
 <j:jelly xmlns:j="jelly:core"
          xmlns:f="/lib/form"
          xmlns:c="/lib/credentials">
-    <f:section title="${%Default HockeyApp Configuration}">
-        <f:entry title="${%Credentials}" field="credentialId">
+    <f:section title="${%Global HockeyApp Configuration}">
+        <f:entry title="${%Credentials}" field="globalCredentialId">
             <c:select/>
         </f:entry>
         <f:entry title="${%HTTP Client Timeout}" field="timeout">

--- a/src/main/resources/hockeyapp/HockeyappRecorder/help-credentialsId.html
+++ b/src/main/resources/hockeyapp/HockeyappRecorder/help-credentialsId.html
@@ -1,0 +1,7 @@
+<div>
+    Your HockeyApp API Token.<br/>
+    Can be <a href="https://rink.hockeyapp.net/manage/auth_tokens">generated</a> in your HockeyApp account
+    settings.<br/>
+    You need to create a token with full access if you mark your releases as be available for download as soon as
+    they're uploaded.
+</div>

--- a/src/main/resources/hockeyapp/HockeyappRecorder/help-defaultToken.html
+++ b/src/main/resources/hockeyapp/HockeyappRecorder/help-defaultToken.html
@@ -1,3 +1,0 @@
-<div>
-    Default token if none specified per build.
-</div>

--- a/src/test/java/hockeyapp/builder/HockeyappApplicationBuilder.java
+++ b/src/test/java/hockeyapp/builder/HockeyappApplicationBuilder.java
@@ -9,6 +9,7 @@ public class HockeyappApplicationBuilder {
     public static final String FILE_PATH = "test.ipa";
 
     private String apiToken = "API_TOKEN";
+    private String credentialId = "CREDENTIAL_ID";
     private String appId = null;
     private boolean notifyTeam = false;
     private String filePath = FILE_PATH;
@@ -24,6 +25,11 @@ public class HockeyappApplicationBuilder {
 
     public HockeyappApplicationBuilder setApiToken(String apiToken) {
         this.apiToken = apiToken;
+        return this;
+    }
+
+    public HockeyappApplicationBuilder setCredentialId(String credentialId) {
+        this.credentialId = credentialId;
         return this;
     }
 
@@ -88,6 +94,6 @@ public class HockeyappApplicationBuilder {
     }
 
     public HockeyappApplication create() {
-        return new HockeyappApplication(apiToken, appId, notifyTeam, filePath, dsymPath, libsPath, tags, teams, mandatory, downloadAllowed, oldVersionHolder, releaseNotesMethod, uploadMethod);
+        return new HockeyappApplication(credentialId, notifyTeam, filePath, dsymPath, libsPath, tags, teams, mandatory, downloadAllowed, oldVersionHolder, releaseNotesMethod, uploadMethod);
     }
 }


### PR DESCRIPTION
Attempt to add support for Credentials handling as the old method stored credentials in plain text.

Note: This plugin is to be deprecated soon as the HockeyApp service is going to be closed at the end of the year. So I don't particularly mind if the implementation could be better. The whole plugin is going to be re-written anyway. 

I have attempted to provide a migration mechanism for free style jobs so *am* interested if that implementation works. I haven't found a way to do that for Pipeline jobs so will list some instructions on the release page after merging this.