### PR TITLE
Favour Secret tokens over String tokens

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>hockeyapp</artifactId>
-    <version>1.4.1-SNAPSHOT</version>
+    <version>1.5.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
     <properties>
         <jenkins.version>2.73.3</jenkins.version>
         <java.level>8</java.level>
+        <hpi.compatibleSinceVersion>1.5.0</hpi.compatibleSinceVersion>
     </properties>
 
     <name>HockeyApp Plugin</name>

--- a/src/main/resources/hockeyapp/HockeyappApplication/config.jelly
+++ b/src/main/resources/hockeyapp/HockeyappApplication/config.jelly
@@ -2,8 +2,9 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler"
          xmlns:f="/lib/form">
 
-    <f:entry title="${%API Token}" field="apiToken">
-        <f:textbox checkUrl="'descriptorByName/hockeyapp.HockeyappApplication/checkApiToken?value='+escape(this.value)"/>
+    <f:entry title="${%API Token}" field="apiTokenSecret">
+        <f:password
+                checkUrl="'descriptorByName/hockeyapp.HockeyappApplication/checkApiToken?value='+escape(this.value)"/>
     </f:entry>
     <f:entry title="${%Upload Method}">
         <table width="100%">
@@ -27,7 +28,8 @@
     </f:entry>
 
     <f:entry title="${%App File} (${%.ipa, .app.zip, .apk})" field="filePath">
-        <f:textbox checkUrl="'descriptorByName/hockeyapp.HockeyappApplication/checkFilePath?value='+escape(this.value)"/>
+        <f:textbox
+                checkUrl="'descriptorByName/hockeyapp.HockeyappApplication/checkFilePath?value='+escape(this.value)"/>
     </f:entry>
     <f:entry title="${%Symbols} (${%.dSYM.zip or mapping.txt})" field="dsymPath">
         <f:textbox/>
@@ -98,7 +100,8 @@
     <f:entry>
         <div align="right">
             <input type="button" value="${%Add an application}..." class="repeatable-add show-if-last"/>
-            <input type="button" value="${%Delete}" class="repeatable-delete show-if-not-only" style="margin-left: 1em;"/>
+            <input type="button" value="${%Delete}" class="repeatable-delete show-if-not-only"
+                   style="margin-left: 1em;"/>
         </div>
     </f:entry>
 </j:jelly>

--- a/src/main/resources/hockeyapp/HockeyappRecorder/global.jelly
+++ b/src/main/resources/hockeyapp/HockeyappRecorder/global.jelly
@@ -2,7 +2,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:section title="${%Default HockeyApp Configuration}">
         <f:entry title="${%Default API Token}" field="defaultToken">
-            <f:textbox/>
+            <f:password/>
         </f:entry>
         <f:entry title="${%HTTP Client Timeout}" field="timeout">
             <f:textbox


### PR DESCRIPTION
Deprecates the use of String tokens as the old method stored credentials in plain text.

Note: This plugin is to be deprecated soon as the HockeyApp service is going to be closed at the end of the year. So I don't particularly mind if the implementation could be better. The whole plugin is going to be re-written anyway.

This is an alternative to #59 . I'll be happy to accept one or the other. I don't think we need both.