### PR TITLE
[JENKINS-57319] Pipeline fails with incorrect type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,6 @@
     <properties>
         <jenkins.version>2.73.3</jenkins.version>
         <java.level>8</java.level>
-        <hpi.compatibleSinceVersion>1.5.0</hpi.compatibleSinceVersion>
     </properties>
 
     <name>HockeyApp Plugin</name>

--- a/src/main/java/hockeyapp/HockeyappApplication.java
+++ b/src/main/java/hockeyapp/HockeyappApplication.java
@@ -7,6 +7,7 @@ import hudson.Util;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
 import hudson.util.FormValidation;
+import hudson.util.Secret;
 import jenkins.model.Jenkins;
 import net.hockeyapp.jenkins.RadioButtonSupport;
 import net.hockeyapp.jenkins.RadioButtonSupportDescriptor;
@@ -32,7 +33,7 @@ public class HockeyappApplication implements Describable<HockeyappApplication> {
     @Deprecated
     public long schemaVersion; // TODO: Fix Findbugs gracefully.
 
-    public String apiToken;
+    public Secret apiToken;
 
     @SuppressFBWarnings(value = {"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"}, justification = "Breaks binary compatibility if removed.")
     @Deprecated
@@ -56,7 +57,7 @@ public class HockeyappApplication implements Describable<HockeyappApplication> {
                                 boolean downloadAllowed, OldVersionHolder oldVersionHolder,
                                 RadioButtonSupport releaseNotesMethod, RadioButtonSupport uploadMethod) {
         this.schemaVersion = SCHEMA_VERSION_NUMBER;
-        this.apiToken = Util.fixEmptyAndTrim(apiToken);
+        this.apiToken = Secret.fromString(apiToken);
         this.appId = Util.fixEmptyAndTrim(appId);
         this.notifyTeam = notifyTeam;
         this.filePath = Util.fixEmptyAndTrim(filePath);
@@ -165,9 +166,9 @@ public class HockeyappApplication implements Describable<HockeyappApplication> {
                         (HockeyappRecorder.DescriptorImpl) activeInstance.getDescriptorOrDie(HockeyappRecorder.class);
 
                 if (hockeyappRecorderDescriptor != null) {
-                    String defaultToken = hockeyappRecorderDescriptor.getDefaultToken();
+                    Secret defaultToken = hockeyappRecorderDescriptor.getDefaultToken();
 
-                    if (defaultToken != null && defaultToken.length() > 0) {
+                    if (defaultToken != null) {
                         return FormValidation.warning("Default API Token is used.");
                     }
                 }

--- a/src/main/java/hockeyapp/HockeyappRecorder.java
+++ b/src/main/java/hockeyapp/HockeyappRecorder.java
@@ -25,6 +25,7 @@ import hudson.tasks.Publisher;
 import hudson.tasks.Recorder;
 import hudson.util.FormValidation;
 import hudson.util.RunList;
+import hudson.util.Secret;
 import jenkins.model.Jenkins;
 import jenkins.tasks.SimpleBuildStep;
 import net.hockeyapp.jenkins.releaseNotes.FileReleaseNotes;
@@ -179,7 +180,7 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
     }
 
     // Not a getter since build has to know proper value
-    public String fetchApiToken(HockeyappApplication application) {
+    public Secret fetchApiToken(HockeyappApplication application) {
         if (application.apiToken == null) {
             return getDescriptor().getDefaultToken();
         } else {
@@ -331,7 +332,8 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
                             : new HttpPost(url.toURI());
 
                     FileBody fileBody = new FileBody(file);
-                    httpRequest.setHeader("X-HockeyAppToken", vars.expand(fetchApiToken(application)));
+                    final Secret secret = fetchApiToken(application);
+                    httpRequest.setHeader("X-HockeyAppToken", vars.expand(Secret.toString(secret)));
                     MultipartEntity entity = new MultipartEntity();
 
                     if (application.releaseNotesMethod != null) {
@@ -689,7 +691,8 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
             URL url = new URL(host, path);
             HttpClient httpclient = createPreconfiguredHttpClient(url, logger);
             HttpPost httpPost = new HttpPost(url.toURI());
-            httpPost.setHeader("X-HockeyAppToken", vars.expand(fetchApiToken(application)));
+            final Secret secret = fetchApiToken(application);
+            httpPost.setHeader("X-HockeyAppToken", vars.expand(Secret.toString(secret)));
             List<NameValuePair> nameValuePairs = new ArrayList<>(1);
             nameValuePairs.add(new BasicNameValuePair("keep", application.getNumberOldVersions()));
             nameValuePairs.add(new BasicNameValuePair("sort", application.getSortOldVersions()));
@@ -751,7 +754,7 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
     // point.
     public static final class DescriptorImpl extends
             BuildStepDescriptor<Publisher> {
-        private String defaultToken;
+        private Secret defaultToken;
         private boolean globalDebugMode = false;
         private String timeout;
 
@@ -760,13 +763,13 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
             load();
         }
 
-        public String getDefaultToken() {
+        public Secret getDefaultToken() {
             return defaultToken;
         }
 
         @SuppressWarnings("unused") // Used by Jenkins
         public void setDefaultToken(String defaultToken) {
-            this.defaultToken = Util.fixEmptyAndTrim(defaultToken);
+            this.defaultToken = Secret.fromString(defaultToken);
             save();
         }
 

--- a/src/main/java/hockeyapp/HockeyappRecorder.java
+++ b/src/main/java/hockeyapp/HockeyappRecorder.java
@@ -25,7 +25,6 @@ import hudson.tasks.Publisher;
 import hudson.tasks.Recorder;
 import hudson.util.FormValidation;
 import hudson.util.RunList;
-import hudson.util.Secret;
 import jenkins.model.Jenkins;
 import jenkins.tasks.SimpleBuildStep;
 import net.hockeyapp.jenkins.releaseNotes.FileReleaseNotes;
@@ -181,12 +180,10 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
 
     // Not a getter since build has to know proper value
     public String fetchApiToken(HockeyappApplication application) {
-        final Secret token = application.getApiTokenSecret();
-
-        if (token == null) {
-            return Secret.toString(getDescriptor().getDefaultTokenSecret());
+        if (application.apiToken == null) {
+            return getDescriptor().getDefaultToken();
         } else {
-            return Secret.toString(token);
+            return application.apiToken;
         }
     }
 
@@ -754,9 +751,7 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
     // point.
     public static final class DescriptorImpl extends
             BuildStepDescriptor<Publisher> {
-        @Deprecated
-        private transient String defaultToken;
-        private Secret defaultTokenSecret;
+        private String defaultToken;
         private boolean globalDebugMode = false;
         private String timeout;
 
@@ -765,33 +760,14 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
             load();
         }
 
-        @Deprecated
         public String getDefaultToken() {
             return defaultToken;
         }
 
-        @Deprecated
         @SuppressWarnings("unused") // Used by Jenkins
         public void setDefaultToken(String defaultToken) {
             this.defaultToken = Util.fixEmptyAndTrim(defaultToken);
             save();
-        }
-
-        public Object readResolve() {
-            if (defaultToken != null) {
-                final Secret secret = Secret.fromString(defaultToken);
-                setDefaultTokenSecret(secret);
-            }
-
-            return this;
-        }
-
-        public Secret getDefaultTokenSecret() {
-            return defaultTokenSecret;
-        }
-
-        public void setDefaultTokenSecret(Secret defaultTokenSecret) {
-            this.defaultTokenSecret = defaultTokenSecret;
         }
 
         public boolean getGlobalDebugMode() {
@@ -883,6 +859,7 @@ public class HockeyappRecorder extends Recorder implements SimpleBuildStep {
                 return FormValidation.ok();
             }
         }
+
     }
 
     private static class EnvAction implements EnvironmentContributingAction {

--- a/src/main/resources/hockeyapp/HockeyappApplication/config.jelly
+++ b/src/main/resources/hockeyapp/HockeyappApplication/config.jelly
@@ -3,7 +3,8 @@
          xmlns:f="/lib/form">
 
     <f:entry title="${%API Token}" field="apiToken">
-        <f:textbox checkUrl="'descriptorByName/hockeyapp.HockeyappApplication/checkApiToken?value='+escape(this.value)"/>
+        <f:password
+                checkUrl="'descriptorByName/hockeyapp.HockeyappApplication/checkApiToken?value='+escape(this.value)"/>
     </f:entry>
     <f:entry title="${%Upload Method}">
         <table width="100%">
@@ -27,7 +28,8 @@
     </f:entry>
 
     <f:entry title="${%App File} (${%.ipa, .app.zip, .apk})" field="filePath">
-        <f:textbox checkUrl="'descriptorByName/hockeyapp.HockeyappApplication/checkFilePath?value='+escape(this.value)"/>
+        <f:textbox
+                checkUrl="'descriptorByName/hockeyapp.HockeyappApplication/checkFilePath?value='+escape(this.value)"/>
     </f:entry>
     <f:entry title="${%Symbols} (${%.dSYM.zip or mapping.txt})" field="dsymPath">
         <f:textbox/>
@@ -98,7 +100,8 @@
     <f:entry>
         <div align="right">
             <input type="button" value="${%Add an application}..." class="repeatable-add show-if-last"/>
-            <input type="button" value="${%Delete}" class="repeatable-delete show-if-not-only" style="margin-left: 1em;"/>
+            <input type="button" value="${%Delete}" class="repeatable-delete show-if-not-only"
+                   style="margin-left: 1em;"/>
         </div>
     </f:entry>
 </j:jelly>

--- a/src/main/resources/hockeyapp/HockeyappApplication/config.jelly
+++ b/src/main/resources/hockeyapp/HockeyappApplication/config.jelly
@@ -2,9 +2,8 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler"
          xmlns:f="/lib/form">
 
-    <f:entry title="${%API Token}" field="apiTokenSecret">
-        <f:password
-                checkUrl="'descriptorByName/hockeyapp.HockeyappApplication/checkApiToken?value='+escape(this.value)"/>
+    <f:entry title="${%API Token}" field="apiToken">
+        <f:textbox checkUrl="'descriptorByName/hockeyapp.HockeyappApplication/checkApiToken?value='+escape(this.value)"/>
     </f:entry>
     <f:entry title="${%Upload Method}">
         <table width="100%">
@@ -28,8 +27,7 @@
     </f:entry>
 
     <f:entry title="${%App File} (${%.ipa, .app.zip, .apk})" field="filePath">
-        <f:textbox
-                checkUrl="'descriptorByName/hockeyapp.HockeyappApplication/checkFilePath?value='+escape(this.value)"/>
+        <f:textbox checkUrl="'descriptorByName/hockeyapp.HockeyappApplication/checkFilePath?value='+escape(this.value)"/>
     </f:entry>
     <f:entry title="${%Symbols} (${%.dSYM.zip or mapping.txt})" field="dsymPath">
         <f:textbox/>
@@ -100,8 +98,7 @@
     <f:entry>
         <div align="right">
             <input type="button" value="${%Add an application}..." class="repeatable-add show-if-last"/>
-            <input type="button" value="${%Delete}" class="repeatable-delete show-if-not-only"
-                   style="margin-left: 1em;"/>
+            <input type="button" value="${%Delete}" class="repeatable-delete show-if-not-only" style="margin-left: 1em;"/>
         </div>
     </f:entry>
 </j:jelly>

--- a/src/main/resources/hockeyapp/HockeyappRecorder/global.jelly
+++ b/src/main/resources/hockeyapp/HockeyappRecorder/global.jelly
@@ -2,7 +2,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:section title="${%Default HockeyApp Configuration}">
         <f:entry title="${%Default API Token}" field="defaultToken">
-            <f:textbox/>
+            <f:password/>
         </f:entry>
         <f:entry title="${%HTTP Client Timeout}" field="timeout">
             <f:textbox

--- a/src/main/resources/hockeyapp/HockeyappRecorder/global.jelly
+++ b/src/main/resources/hockeyapp/HockeyappRecorder/global.jelly
@@ -2,7 +2,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:section title="${%Default HockeyApp Configuration}">
         <f:entry title="${%Default API Token}" field="defaultToken">
-            <f:password/>
+            <f:textbox/>
         </f:entry>
         <f:entry title="${%HTTP Client Timeout}" field="timeout">
             <f:textbox


### PR DESCRIPTION
This is a second attempt to fix the token stored in plain text issue from #60. Hopefully this works with existing pipelines too.

An example of a secure pipeline would be:

```
stage ('Upload HockeyApp') {
	    environment { 
                HOCKETAPP_TOKEN = credentials('hockeyapp-secret') 
            }
		steps {
			hockeyApp applications: [
				[
				 	apiToken: env.HOCKETAPP_TOKEN, 
					downloadAllowed: true, 
					filePath: 'sample.apk', 
					mandatory: false, 
					notifyTeam: true, 
					releaseNotesMethod: changelog(), 
					uploadMethod: appCreation(false)
				]
			], debugMode: false, failGracefully: false
		}		
	}
```

You will need to create a secure credential in Jenkins of type Secret text and refer to it by its id in a pipeline.